### PR TITLE
refactor(frontend): PR-0252 P0-1 add workspace port abstraction

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/workspace_port.dart
+++ b/apps/lazynote_flutter/lib/features/notes/workspace_port.dart
@@ -1,0 +1,28 @@
+typedef WorkspacePortSnapshot = ({
+  List<String> paneOrder,
+  String activePaneId,
+  Map<String, List<String>> openTabsByPane,
+});
+
+/// Notes->workspace boundary interface (D7).
+abstract interface class WorkspacePort {
+  String? get activeNoteId;
+  String get activeDraftContent;
+  bool hasDraftBuffer(String noteId);
+
+  WorkspacePortSnapshot snapshot();
+  void beginBatchSync();
+  void endBatchSync();
+  void resetAll();
+
+  void syncExternalNote({
+    required String noteId,
+    required String persistedContent,
+    required String draftContent,
+    required String saveState,
+    bool activate = false,
+    String? paneId,
+  });
+
+  void syncSaveState({required String noteId, required String saveState});
+}

--- a/docs/releases/v0.2.5/prs/PR-0252/P0-1-workspace-port.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P0-1-workspace-port.md
@@ -29,7 +29,7 @@
 ## Prerequisites
 
 - 无前置任务（Phase 0 起始任务）
-- Section 2.3 前置条件全部满足（0255A/B 签字、flutter analyze 零警告、测试基线 312/1）
+- Section 2.3 前置条件全部满足（0255A/B 签字、flutter analyze 零警告、测试基线 313/0）
 
 ## Scope
 


### PR DESCRIPTION
## Summary

This PR delivers `PR-0252 P0-1` by introducing a notes-side workspace boundary interface:

- Added `apps/lazynote_flutter/lib/features/notes/workspace_port.dart` (24 lines)
- Defined `WorkspacePort` + `WorkspacePortSnapshot` as the D7 abstraction seam
- Kept zero direct `features/workspace/` imports in the new port file

This is a pure interface baseline for later extraction work (`P1-1 WorkspaceTreeManager`) and does not change runtime behavior.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test` (313 pass / 0 known-fail)
- `flutter build windows --debug`

All checks passed.
