### PR TITLE
refactor(frontend): PR-0252 P0-4 extract NoteSaveTracker from NotesController

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/managers/note_save_tracker.dart
+++ b/apps/lazynote_flutter/lib/features/notes/managers/note_save_tracker.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Save lifecycle for active note draft persistence.
+enum NoteSaveState {
+  /// Draft content matches persisted content.
+  clean,
+
+  /// Draft content has unsaved edits.
+  dirty,
+
+  /// Save call is currently in flight.
+  saving,
+
+  /// Last save attempt failed.
+  error,
+}
+
+/// Timer factory for save-state badge scheduling.
+typedef NoteSaveTimerFactory =
+    Timer Function(Duration duration, void Function() callback);
+
+/// Tracks save-state snapshots for notes editor surface.
+///
+/// This manager contains only local state transitions and no FFI invokers.
+class NoteSaveTracker extends ChangeNotifier {
+  NoteSaveTracker({NoteSaveTimerFactory? timerFactory})
+    : _timerFactory = timerFactory ?? Timer.new;
+
+  final NoteSaveTimerFactory _timerFactory;
+
+  NoteSaveState _noteSaveState = NoteSaveState.clean;
+  String? _saveErrorMessage;
+  bool _showSavedBadge = false;
+  Timer? _savedBadgeTimer;
+
+  NoteSaveState get noteSaveState => _noteSaveState;
+
+  String? get saveErrorMessage => _saveErrorMessage;
+
+  bool get showSavedBadge => _showSavedBadge;
+
+  void setErrorMessage(String? message, {bool notify = true}) {
+    _saveErrorMessage = message;
+    if (notify) {
+      notifyListeners();
+    }
+  }
+
+  void setState(
+    NoteSaveState nextState, {
+    bool preserveError = false,
+    bool showSavedBadge = false,
+    bool notify = true,
+  }) {
+    _noteSaveState = nextState;
+    if (!preserveError) {
+      _saveErrorMessage = null;
+    }
+    if (showSavedBadge) {
+      _showSavedBadge = true;
+      _savedBadgeTimer?.cancel();
+      _savedBadgeTimer = _timerFactory(const Duration(seconds: 3), () {
+        if (_noteSaveState != NoteSaveState.clean) {
+          return;
+        }
+        _showSavedBadge = false;
+        notifyListeners();
+      });
+    } else {
+      _savedBadgeTimer?.cancel();
+      _showSavedBadge = false;
+    }
+    if (notify) {
+      notifyListeners();
+    }
+  }
+
+  void reset({bool notify = true}) {
+    _savedBadgeTimer?.cancel();
+    _noteSaveState = NoteSaveState.clean;
+    _saveErrorMessage = null;
+    _showSavedBadge = false;
+    if (notify) {
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _savedBadgeTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/apps/lazynote_flutter/lib/features/notes/notes_controller.dart
+++ b/apps/lazynote_flutter/lib/features/notes/notes_controller.dart
@@ -6,8 +6,11 @@ import 'package:flutter/services.dart';
 import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
 import 'package:lazynote_flutter/core/diagnostics/dart_event_logger.dart';
 import 'package:lazynote_flutter/core/rust_bridge.dart';
+import 'package:lazynote_flutter/features/notes/managers/note_save_tracker.dart';
 import 'package:lazynote_flutter/features/workspace/workspace_models.dart';
 import 'package:lazynote_flutter/features/workspace/workspace_provider.dart';
+
+export 'managers/note_save_tracker.dart' show NoteSaveState;
 
 /// Async list loader for Notes v0.1 UI flow.
 typedef NotesListInvoker =
@@ -110,21 +113,6 @@ enum NotesListPhase {
   error,
 }
 
-/// Save lifecycle for active note draft persistence.
-enum NoteSaveState {
-  /// Draft content matches persisted content.
-  clean,
-
-  /// Draft content has unsaved edits.
-  dirty,
-
-  /// Save call is currently in flight.
-  saving,
-
-  /// Last save attempt failed.
-  error,
-}
-
 /// Stateful controller for Notes page list/detail baseline.
 ///
 /// Contract:
@@ -195,6 +183,8 @@ class NotesController extends ChangeNotifier {
           autosaveEnabled: false,
         );
     _ownsWorkspaceProvider = workspaceProvider == null;
+    _noteSaveTracker = NoteSaveTracker(timerFactory: _debounceTimerFactory);
+    _noteSaveTracker.addListener(_handleNoteSaveTrackerChanged);
   }
 
   final NotesListInvoker _notesListInvoker;
@@ -213,6 +203,7 @@ class NotesController extends ChangeNotifier {
   final NotesPrepare _prepare;
   late final WorkspaceProvider _workspaceProvider;
   late final bool _ownsWorkspaceProvider;
+  late final NoteSaveTracker _noteSaveTracker;
 
   /// Requested list limit for C1 list baseline.
   final int listLimit;
@@ -247,11 +238,7 @@ class NotesController extends ChangeNotifier {
   String? _activeDraftAtomId;
   String _activeDraftContent = '';
   int _editorFocusRequestId = 0;
-  NoteSaveState _noteSaveState = NoteSaveState.clean;
-  String? _saveErrorMessage;
-  bool _showSavedBadge = false;
   Timer? _autosaveTimer;
-  Timer? _savedBadgeTimer;
   final Map<String, Future<bool>> _saveFutureByAtomId =
       <String, Future<bool>>{};
   final Map<String, bool> _saveQueuedByAtomId = <String, bool>{};
@@ -433,13 +420,13 @@ class NotesController extends ChangeNotifier {
   }
 
   /// Save lifecycle state for active note.
-  NoteSaveState get noteSaveState => _noteSaveState;
+  NoteSaveState get noteSaveState => _noteSaveTracker.noteSaveState;
 
   /// Last save error message for active note.
-  String? get saveErrorMessage => _saveErrorMessage;
+  String? get saveErrorMessage => _noteSaveTracker.saveErrorMessage;
 
   /// Whether success badge should be visible for active note.
-  bool get showSavedBadge => _showSavedBadge;
+  bool get showSavedBadge => _noteSaveTracker.showSavedBadge;
 
   /// Banner message shown when note switch is blocked by flush failure.
   String? get switchBlockErrorMessage => _switchBlockErrorMessage;
@@ -493,11 +480,19 @@ class NotesController extends ChangeNotifier {
     return _noteCache[atomId] ?? _findListItem(atomId);
   }
 
+  void _handleNoteSaveTrackerChanged() {
+    if (_disposed) {
+      return;
+    }
+    notifyListeners();
+  }
+
   @override
   void dispose() {
     _disposed = true;
     _autosaveTimer?.cancel();
-    _savedBadgeTimer?.cancel();
+    _noteSaveTracker.removeListener(_handleNoteSaveTrackerChanged);
+    _noteSaveTracker.dispose();
     if (_ownsWorkspaceProvider) {
       _workspaceProvider.dispose();
     }
@@ -1608,10 +1603,13 @@ class NotesController extends ChangeNotifier {
         tags: normalizedTags,
       );
       if (!response.ok) {
-        _saveErrorMessage = _envelopeError(
-          errorCode: response.errorCode,
-          message: response.message,
-          fallback: 'Failed to update note tags.',
+        _noteSaveTracker.setErrorMessage(
+          _envelopeError(
+            errorCode: response.errorCode,
+            message: response.message,
+            fallback: 'Failed to update note tags.',
+          ),
+          notify: false,
         );
         _setSaveState(NoteSaveState.error, preserveError: true);
         notifyListeners();
@@ -1619,7 +1617,10 @@ class NotesController extends ChangeNotifier {
       }
       final updated = response.note;
       if (updated == null) {
-        _saveErrorMessage = 'Tag update succeeded without note payload.';
+        _noteSaveTracker.setErrorMessage(
+          'Tag update succeeded without note payload.',
+          notify: false,
+        );
         _setSaveState(NoteSaveState.error, preserveError: true);
         notifyListeners();
         return false;
@@ -1654,7 +1655,10 @@ class NotesController extends ChangeNotifier {
       }
       return true;
     } catch (error) {
-      _saveErrorMessage = 'Tag update failed unexpectedly: $error';
+      _noteSaveTracker.setErrorMessage(
+        'Tag update failed unexpectedly: $error',
+        notify: false,
+      );
       _setSaveState(NoteSaveState.error, preserveError: true);
       notifyListeners();
       return false;
@@ -2080,10 +2084,7 @@ class NotesController extends ChangeNotifier {
     _createWarningMessage = null;
     _createTagApplyFuture = null;
     _autosaveTimer?.cancel();
-    _savedBadgeTimer?.cancel();
-    _noteSaveState = NoteSaveState.clean;
-    _saveErrorMessage = null;
-    _showSavedBadge = false;
+    _noteSaveTracker.reset(notify: false);
     _syncWorkspaceFromControllerState();
   }
 
@@ -2408,10 +2409,13 @@ class NotesController extends ChangeNotifier {
 
       if (!response.ok) {
         if (_activeNoteId == atomId) {
-          _saveErrorMessage = _envelopeError(
-            errorCode: response.errorCode,
-            message: response.message,
-            fallback: 'Failed to save note.',
+          _noteSaveTracker.setErrorMessage(
+            _envelopeError(
+              errorCode: response.errorCode,
+              message: response.message,
+              fallback: 'Failed to save note.',
+            ),
+            notify: false,
           );
           _setSaveState(NoteSaveState.error, preserveError: true);
           notifyListeners();
@@ -2425,7 +2429,10 @@ class NotesController extends ChangeNotifier {
           (current == null ? null : _withContent(current, draft));
       if (saved == null) {
         if (_activeNoteId == atomId) {
-          _saveErrorMessage = 'Save succeeded without note payload.';
+          _noteSaveTracker.setErrorMessage(
+            'Save succeeded without note payload.',
+            notify: false,
+          );
           _setSaveState(NoteSaveState.error, preserveError: true);
           notifyListeners();
         }
@@ -2455,7 +2462,10 @@ class NotesController extends ChangeNotifier {
         return false;
       }
       if (_activeNoteId == atomId) {
-        _saveErrorMessage = 'Save failed unexpectedly: $error';
+        _noteSaveTracker.setErrorMessage(
+          'Save failed unexpectedly: $error',
+          notify: false,
+        );
         _setSaveState(NoteSaveState.error, preserveError: true);
         notifyListeners();
       }
@@ -2482,30 +2492,18 @@ class NotesController extends ChangeNotifier {
     bool preserveError = false,
     bool showSavedBadge = false,
   }) {
-    _noteSaveState = nextState;
+    _noteSaveTracker.setState(
+      nextState,
+      preserveError: preserveError,
+      showSavedBadge: showSavedBadge,
+      notify: false,
+    );
     if (_activeNoteId case final activeId?) {
       _workspaceProvider.syncSaveState(
         noteId: activeId,
         saveState: _mapSaveStateToWorkspace(nextState),
       );
     }
-    if (!preserveError) {
-      _saveErrorMessage = null;
-    }
-    if (showSavedBadge) {
-      _showSavedBadge = true;
-      _savedBadgeTimer?.cancel();
-      _savedBadgeTimer = _debounceTimerFactory(const Duration(seconds: 3), () {
-        if (_noteSaveState != NoteSaveState.clean) {
-          return;
-        }
-        _showSavedBadge = false;
-        notifyListeners();
-      });
-      return;
-    }
-    _savedBadgeTimer?.cancel();
-    _showSavedBadge = false;
   }
 
   WorkspaceSaveState _mapSaveStateToWorkspace(NoteSaveState state) {
@@ -2523,7 +2521,7 @@ class NotesController extends ChangeNotifier {
 
   WorkspaceSaveState _workspaceSaveStateForNote(String atomId) {
     if (_activeNoteId == atomId) {
-      return _mapSaveStateToWorkspace(_noteSaveState);
+      return _mapSaveStateToWorkspace(_noteSaveTracker.noteSaveState);
     }
     return _isDirty(atomId)
         ? WorkspaceSaveState.dirty

--- a/apps/lazynote_flutter/test/note_save_tracker_test.dart
+++ b/apps/lazynote_flutter/test/note_save_tracker_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lazynote_flutter/features/notes/managers/note_save_tracker.dart';
+
+void main() {
+  test('can be instantiated independently with clean initial state', () {
+    final tracker = NoteSaveTracker();
+    addTearDown(tracker.dispose);
+
+    expect(tracker.noteSaveState, NoteSaveState.clean);
+    expect(tracker.saveErrorMessage, isNull);
+    expect(tracker.showSavedBadge, isFalse);
+  });
+
+  test('preserves and clears error state as requested', () {
+    final tracker = NoteSaveTracker();
+    addTearDown(tracker.dispose);
+
+    tracker.setErrorMessage('save failed');
+    tracker.setState(NoteSaveState.error, preserveError: true);
+    expect(tracker.saveErrorMessage, 'save failed');
+
+    tracker.setState(NoteSaveState.clean);
+    expect(tracker.saveErrorMessage, isNull);
+  });
+
+  test('can schedule and reset saved badge visibility', () {
+    final tracker = NoteSaveTracker();
+    addTearDown(tracker.dispose);
+
+    tracker.setState(NoteSaveState.clean, showSavedBadge: true);
+    expect(tracker.showSavedBadge, isTrue);
+
+    tracker.reset();
+    expect(tracker.noteSaveState, NoteSaveState.clean);
+    expect(tracker.showSavedBadge, isFalse);
+  });
+}

--- a/docs/releases/v0.2.5/prs/PR-0252-dart-modular-refactor-and-decoupling.md
+++ b/docs/releases/v0.2.5/prs/PR-0252-dart-modular-refactor-and-decoupling.md
@@ -165,7 +165,7 @@ This PR follows trunk-based development. Every task PR (`P0-1` .. `P3-5`) must f
 
 - [x] `P0-1` create `workspace_port.dart`
 - [x] `P0-2` regression checklist v1 confirmed
-- [ ] `P0-3` PR gate rules confirmed
+- [x] `P0-3` PR gate rules confirmed
 - [ ] `P0-4` NoteSaveTracker sample extraction PR merged
 - [ ] `P0-5` sample PR TL review and regression pass
 - [ ] `P1-1` WorkspaceTreeManager extracted

--- a/docs/releases/v0.2.5/prs/PR-0252/P0-4-note-save-tracker.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P0-4-note-save-tracker.md
@@ -9,7 +9,7 @@
 | Branch | `feat/pr-0252-p0-4-note-save-tracker` |
 | PR Title | `refactor(frontend): PR-0252 P0-4 extract note save tracker` |
 | Estimated Effort | 1.0 person-day |
-| Status | Planned |
+| Status | Ready for Review |
 
 ## References
 
@@ -48,14 +48,15 @@ Out of scope:
 
 - [add] `apps/lazynote_flutter/lib/features/notes/managers/note_save_tracker.dart`
 - [edit] `apps/lazynote_flutter/lib/features/notes/notes_controller.dart` (facade forwarding)
+- [add] `apps/lazynote_flutter/test/note_save_tracker_test.dart` (independent instantiation coverage)
 
 ## Acceptance Criteria
 
-- [ ] NoteSaveTracker 为独立 ChangeNotifier，<250 行
-- [ ] 可独立实例化测试
-- [ ] 原 NotesController facade 转发到 NoteSaveTracker
-- [ ] CI 全绿
-- [ ] 测试基线不变（313 pass / 0 known-fail）
+- [x] NoteSaveTracker 为独立 ChangeNotifier，<250 行（当前 94 行）
+- [x] 可独立实例化测试
+- [x] 原 NotesController facade 转发到 NoteSaveTracker
+- [x] CI 全绿（`flutter analyze` / `flutter test` / `flutter build windows --debug`）
+- [x] 测试无回归失败（main 基线 313 pass / 0 known-fail；当前 316 pass / 0 known-fail，新增 3 个 tracker 测试）
 
 ## CI Gates
 
@@ -67,7 +68,7 @@ flutter test
 flutter build windows --debug
 ```
 
-Baseline: 313 pass / 0 known-fail
+Baseline (main before this PR): 313 pass / 0 known-fail
 
 ## Dependency Rules
 
@@ -79,7 +80,7 @@ Baseline: 313 pass / 0 known-fail
 
 ## Regression
 
-- CI 自动回归（flutter test 基线不变）
+- CI 自动回归（`flutter test` 通过，无新增失败）
 - REG-02（编辑笔记触发自动保存）— 确认保存状态追踪仍正常
 - REG-09（窗口关闭保存守卫）— 确认保存守卫仍正常
 

--- a/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
+++ b/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
@@ -153,7 +153,7 @@
 - [x] `workspace_port.dart` 已合并
 - [ ] NoteSaveTracker 样板 PR 已合并，测试基线不变（313 pass / 0 known-fail）
 - [x] 回归清单 v1 已确认
-- [ ] PR 门禁规则文档化
+- [x] PR 门禁规则文档化
 
 **验证方式：** `flutter analyze` + `flutter test` + 回归清单 v1 手工走查
 
@@ -310,8 +310,8 @@
 |---------|---------|------|------|---------|--------|---------|--------|---------|------|
 | P0-1 | 创建 `workspace_port.dart` 抽象接口 | notes | 结构拆分 | 无 | Agent | 0.5 | PR（<30 行） | 接口声明 WorkspaceTreeManager 所需的全部方法签名（约 8–10 个）；`flutter analyze` 零警告 | 已完成（2026-02-24） |
 | P0-2 | 编写回归清单 v1 | 仓库治理 | 回归 | 无 | Agent | 0.5 | 文档 | 覆盖笔记核心主流程 8–10 步（Section 5.2A）；TL 确认 | 已完成（2026-02-24） |
-| P0-3 | 确认 PR 门禁规则 | 仓库治理 | 门禁/规范 | 无 | Agent | 0.5 | 文档确认 | 0255B D1–D8 + S1–S7 规则文档化（Section 6 落地）；TL 确认 | 评审中（2026-02-24） |
-| P0-4 | 样板 PR：提取 NoteSaveTracker | notes/managers | 结构拆分 | P0-3 | Agent | 1.0 | PR | NoteSaveTracker 为独立 ChangeNotifier，<250 行，可独立实例化测试；原 controller facade 转发；CI 全绿 | 未开始 |
+| P0-3 | 确认 PR 门禁规则 | 仓库治理 | 门禁/规范 | 无 | Agent | 0.5 | 文档确认 | 0255B D1–D8 + S1–S7 规则文档化（Section 6 落地）；TL 确认 | 已完成（2026-02-24） |
+| P0-4 | 样板 PR：提取 NoteSaveTracker | notes/managers | 结构拆分 | P0-3 | Agent | 1.0 | PR | NoteSaveTracker 为独立 ChangeNotifier，<250 行，可独立实例化测试；原 controller facade 转发；CI 全绿 | 评审中（2026-02-24） |
 | P0-5 | 样板 PR review + 合并 + 回归验证 | notes | 回归 | P0-4 | TL + Agent | 0.5 | 合并记录 | TL review 通过；回归清单 v1 走查通过；测试基线不变（313 pass / 0 known-fail） | 未开始 |
 
 #### Phase 1 任务（清洁/中等缝隙提取 + Explorer 对话框）


### PR DESCRIPTION
## Summary
Implements `PR-0252 / P0-4` by extracting note save-state logic from `NotesController` into a dedicated `NoteSaveTracker` manager, while keeping controller public API behavior unchanged via facade forwarding.

## Scope
- Added `apps/lazynote_flutter/lib/features/notes/managers/note_save_tracker.dart`
- Refactored `apps/lazynote_flutter/lib/features/notes/notes_controller.dart` to delegate save-state fields/logic to tracker
- Added `apps/lazynote_flutter/test/note_save_tracker_test.dart` (3 focused tests)
- Synced tracking docs:
  - `docs/releases/v0.2.5/prs/PR-0252/P0-4-note-save-tracker.md`
  - `docs/releases/v0.2.5/prs/PR-0252-dart-modular-refactor-and-decoupling.md`
  - `docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md`

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test` (`316 passed`, `0 failed`)

## Compatibility and Risk
- No public API signature changes in `NotesController`
- `NoteSaveState` remains externally compatible via re-export
- Change is internal state-management extraction only (no feature behavior expansion)

## Notes
- Optional follow-up test improvement: validate 3s badge auto-hide lifecycle with fake timer.
