### PR TITLE
refactor(frontend): PR-0252 P1-4 extract create folder dialog

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/dialogs/create_folder_dialog.dart
+++ b/apps/lazynote_flutter/lib/features/notes/dialogs/create_folder_dialog.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:lazynote_flutter/l10n/app_localizations.dart';
+
+typedef CreateFolderDialogConfirm = void Function(String folderName);
+typedef CreateFolderDialogCancel = void Function();
+
+class CreateFolderDialog extends StatefulWidget {
+  const CreateFolderDialog({
+    super.key,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final CreateFolderDialogConfirm onConfirm;
+  final CreateFolderDialogCancel onCancel;
+
+  @override
+  State<CreateFolderDialog> createState() => _CreateFolderDialogState();
+}
+
+class _CreateFolderDialogState extends State<CreateFolderDialog> {
+  String _draftName = '';
+
+  bool get _canSubmit => _draftName.trim().isNotEmpty;
+
+  String _l10nText({
+    required String fallback,
+    required String Function(AppLocalizations l10n) pick,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    return l10n == null ? fallback : pick(l10n);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const Key('notes_create_folder_dialog'),
+      title: Text(
+        _l10nText(
+          fallback: 'Create folder',
+          pick: (l10n) => l10n.notesCreateFolderDialogTitle,
+        ),
+      ),
+      content: TextField(
+        key: const Key('notes_create_folder_name_input'),
+        autofocus: true,
+        decoration: InputDecoration(
+          hintText: _l10nText(
+            fallback: 'Folder name',
+            pick: (l10n) => l10n.notesFolderNameHint,
+          ),
+        ),
+        onChanged: (value) {
+          setState(() {
+            _draftName = value;
+          });
+        },
+        onSubmitted: (_) {
+          if (_canSubmit) {
+            widget.onConfirm(_draftName.trim());
+          }
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: widget.onCancel,
+          child: Text(
+            _l10nText(fallback: 'Cancel', pick: (l10n) => l10n.commonCancel),
+          ),
+        ),
+        FilledButton.tonal(
+          key: const Key('notes_create_folder_confirm_button'),
+          onPressed: _canSubmit
+              ? () {
+                  widget.onConfirm(_draftName.trim());
+                }
+              : null,
+          child: Text(
+            _l10nText(fallback: 'Create', pick: (l10n) => l10n.commonCreate),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
+++ b/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
+import 'package:lazynote_flutter/features/notes/dialogs/create_folder_dialog.dart';
 import 'package:lazynote_flutter/features/notes/explorer_context_menu.dart';
 import 'package:lazynote_flutter/features/notes/explorer_drag_controller.dart';
 import 'package:lazynote_flutter/features/notes/explorer_tree_item.dart';
@@ -1579,68 +1580,15 @@ class _NoteExplorerState extends State<NoteExplorer> {
       return;
     }
     final messenger = ScaffoldMessenger.maybeOf(context);
-    var draftName = '';
     final folderName = await showDialog<String>(
       context: context,
       builder: (dialogContext) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            final canSubmit = draftName.trim().isNotEmpty;
-            return AlertDialog(
-              key: const Key('notes_create_folder_dialog'),
-              title: Text(
-                _l10nText(
-                  fallback: 'Create folder',
-                  pick: (l10n) => l10n.notesCreateFolderDialogTitle,
-                ),
-              ),
-              content: TextField(
-                key: const Key('notes_create_folder_name_input'),
-                autofocus: true,
-                decoration: InputDecoration(
-                  hintText: _l10nText(
-                    fallback: 'Folder name',
-                    pick: (l10n) => l10n.notesFolderNameHint,
-                  ),
-                ),
-                onChanged: (value) {
-                  draftName = value;
-                  setState(() {});
-                },
-                onSubmitted: (_) {
-                  if (canSubmit) {
-                    Navigator.of(dialogContext).pop(draftName.trim());
-                  }
-                },
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () {
-                    Navigator.of(dialogContext).pop();
-                  },
-                  child: Text(
-                    _l10nText(
-                      fallback: 'Cancel',
-                      pick: (l10n) => l10n.commonCancel,
-                    ),
-                  ),
-                ),
-                FilledButton.tonal(
-                  key: const Key('notes_create_folder_confirm_button'),
-                  onPressed: canSubmit
-                      ? () {
-                          Navigator.of(dialogContext).pop(draftName.trim());
-                        }
-                      : null,
-                  child: Text(
-                    _l10nText(
-                      fallback: 'Create',
-                      pick: (l10n) => l10n.commonCreate,
-                    ),
-                  ),
-                ),
-              ],
-            );
+        return CreateFolderDialog(
+          onConfirm: (value) {
+            Navigator.of(dialogContext).pop(value);
+          },
+          onCancel: () {
+            Navigator.of(dialogContext).pop();
           },
         );
       },

--- a/apps/lazynote_flutter/test/create_folder_dialog_test.dart
+++ b/apps/lazynote_flutter/test/create_folder_dialog_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lazynote_flutter/features/notes/dialogs/create_folder_dialog.dart';
+
+void main() {
+  Widget wrapWithMaterial(Widget child) {
+    return MaterialApp(home: Scaffold(body: child));
+  }
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required ValueChanged<String> onConfirm,
+    required VoidCallback onCancel,
+  }) async {
+    await tester.pumpWidget(
+      wrapWithMaterial(
+        Builder(
+          builder: (context) => FilledButton(
+            key: const Key('open_create_folder_dialog'),
+            onPressed: () {
+              showDialog<String>(
+                context: context,
+                builder: (dialogContext) {
+                  return CreateFolderDialog(
+                    onConfirm: (value) {
+                      onConfirm(value);
+                      Navigator.of(dialogContext).pop(value);
+                    },
+                    onCancel: () {
+                      onCancel();
+                      Navigator.of(dialogContext).pop();
+                    },
+                  );
+                },
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('open_create_folder_dialog')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('confirm button is disabled when input is blank', (
+    WidgetTester tester,
+  ) async {
+    await openDialog(tester, onConfirm: (_) {}, onCancel: () {});
+
+    final confirmButton = tester.widget<FilledButton>(
+      find.byKey(const Key('notes_create_folder_confirm_button')),
+    );
+    expect(confirmButton.onPressed, isNull);
+  });
+
+  testWidgets('confirm submits trimmed folder name', (
+    WidgetTester tester,
+  ) async {
+    String? confirmedName;
+
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        confirmedName = value;
+      },
+      onCancel: () {},
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('notes_create_folder_name_input')),
+      '  Inbox  ',
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const Key('notes_create_folder_confirm_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(confirmedName, 'Inbox');
+    expect(find.byKey(const Key('notes_create_folder_dialog')), findsNothing);
+  });
+
+  testWidgets('cancel and submit action both trigger callbacks', (
+    WidgetTester tester,
+  ) async {
+    var cancelCount = 0;
+    String? submittedName;
+
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        submittedName = value;
+      },
+      onCancel: () {
+        cancelCount += 1;
+      },
+    );
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(cancelCount, 1);
+
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        submittedName = value;
+      },
+      onCancel: () {},
+    );
+    await tester.enterText(
+      find.byKey(const Key('notes_create_folder_name_input')),
+      '  Drafts  ',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(submittedName, 'Drafts');
+    expect(find.byKey(const Key('notes_create_folder_dialog')), findsNothing);
+  });
+}

--- a/docs/releases/v0.2.5/prs/PR-0252/P1-4-create-folder-dialog.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P1-4-create-folder-dialog.md
@@ -9,7 +9,7 @@
 | Branch | `feat/pr-0252-p1-4-create-folder-dialog` |
 | PR Title | `refactor(frontend): PR-0252 P1-4 extract create folder dialog` |
 | Estimated Effort | 0.5 person-day |
-| Status | Planned |
+| Status | Ready for Review |
 
 ## References
 
@@ -46,14 +46,15 @@ Out of scope:
 
 - [add] `apps/lazynote_flutter/lib/features/notes/dialogs/create_folder_dialog.dart`
 - [edit] `apps/lazynote_flutter/lib/features/notes/note_explorer.dart` (import extracted dialog)
+- [add] `apps/lazynote_flutter/test/create_folder_dialog_test.dart`
 
 ## Acceptance Criteria
 
-- [ ] 独立 StatefulWidget，~130 行
-- [ ] 接收回调参数（`onConfirm`, `onCancel`）
-- [ ] 可独立 widget test
-- [ ] CI 全绿
-- [ ] 测试基线不变（313 pass / 0 known-fail）
+- [x] 独立 StatefulWidget，~130 行
+- [x] 接收回调参数（`onConfirm`, `onCancel`）
+- [x] 可独立 widget test
+- [x] CI 全绿
+- [x] 测试基线不变（324 pass / 0 known-fail）
 
 ## CI Gates
 
@@ -73,6 +74,13 @@ flutter build windows --debug
 
 > Note: D6 检查目标目录 `dialogs/` 在本 PR 中首次创建。
 
+## Verification Snapshot (2026-02-25)
+
+- `flutter analyze`：通过（No issues found）
+- `flutter test test/create_folder_dialog_test.dart test/note_explorer_tree_test.dart test/explorer_context_actions_test.dart`：通过
+- `flutter test`：通过（324 pass）
+- D6：`rg -n "import.*(coordinator|manager)" apps/lazynote_flutter/lib/features/notes/dialogs/` 零匹配
+
 ## Regression
 
 - CI 自动回归
@@ -82,4 +90,3 @@ flutter build windows --debug
 ## Rollback
 
 独立 revert 即可。删除 `create_folder_dialog.dart`，回退 `note_explorer.dart` 的 import 改动。
-

--- a/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
+++ b/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
@@ -321,7 +321,7 @@
 | P1-1 | 提取 WorkspaceTreeManager | notes/managers | 结构拆分 | P0-1 | Agent | 2.0 | PR | 独立 ChangeNotifier，持有 workspace ×6 invoker + WorkspacePort，<550 行（物理行 533 / 非空行 499）；原 controller facade 转发；CI 全绿 | 已完成（2026-02-25） |
 | P1-2 | 提取 NoteDraftManager | notes/managers | 结构拆分 | P0-4 | Agent | 1.0 | PR | 独立 ChangeNotifier，持有 noteUpdate invoker，<300 行；自保存定时器隔离；CI 全绿 | 已完成（2026-02-25） |
 | P1-3 | 提取 NoteTagManager | notes/managers | 结构拆分 | 无 | Agent | 1.5 | PR | 独立 ChangeNotifier，持有 noteSetTags + tagsList invoker，<350 行；标签变更队列独立；CI 全绿 | 已完成（2026-02-25） |
-| P1-4 | 提取 CreateFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行，接收回调参数；可独立 widget test；CI 全绿 | 未开始 |
+| P1-4 | 提取 CreateFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行，接收回调参数；可独立 widget test；CI 全绿 | 评审中（2026-02-25） |
 | P1-5 | 提取 DeleteFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~150 行；含 dissolve/delete-all 选择；CI 全绿 | 未开始 |
 | P1-6 | 提取 RenameNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行；CI 全绿 | 未开始 |
 | P1-7 | 提取 MoveNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~160 行；含移动目标加载；CI 全绿 | 未开始 |


### PR DESCRIPTION
**Title**  
`refactor(frontend): PR-0252 P1-4 extract create folder dialog`

**Description**  
This PR delivers `PR-0252 / P1-4` by extracting the inline create-folder dialog from `note_explorer.dart` into an independent widget.

### What changed
- Added `apps/lazynote_flutter/lib/features/notes/dialogs/create_folder_dialog.dart`
- Updated `apps/lazynote_flutter/lib/features/notes/note_explorer.dart` to use `CreateFolderDialog`
- Added independent widget tests in `apps/lazynote_flutter/test/create_folder_dialog_test.dart`
- Synced task/report docs:
  - `docs/releases/v0.2.5/prs/PR-0252/P1-4-create-folder-dialog.md`
  - `docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md`

### Behavior/compatibility
- No user-visible behavior change intended
- Existing dialog keys are preserved for compatibility
- Dialog communicates only through callbacks (`onConfirm`, `onCancel`), aligned with D6 boundary rule

### Validation
- `flutter analyze` passed
- `flutter test` passed (full suite: **324 pass / 0 known-fail**)
- `flutter build windows --debug` passed
- D6 check passed: no `coordinator/manager` imports in `notes/dialogs/`