### PR TITLE
refactor(frontend): PR-0252 P1-6 extract rename node dialog

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/dialogs/rename_node_dialog.dart
+++ b/apps/lazynote_flutter/lib/features/notes/dialogs/rename_node_dialog.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:lazynote_flutter/l10n/app_localizations.dart';
+
+typedef RenameNodeDialogConfirm = void Function(String newName);
+typedef RenameNodeDialogCancel = void Function();
+
+class RenameNodeDialog extends StatefulWidget {
+  const RenameNodeDialog({
+    super.key,
+    required this.initialName,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  final String initialName;
+  final RenameNodeDialogConfirm onConfirm;
+  final RenameNodeDialogCancel onCancel;
+
+  @override
+  State<RenameNodeDialog> createState() => _RenameNodeDialogState();
+}
+
+class _RenameNodeDialogState extends State<RenameNodeDialog> {
+  late String _draftName;
+
+  bool get _canSubmit =>
+      _draftName.trim().isNotEmpty &&
+      _draftName.trim() != widget.initialName.trim();
+
+  String _l10nText({
+    required String fallback,
+    required String Function(AppLocalizations l10n) pick,
+  }) {
+    final l10n = AppLocalizations.of(context);
+    return l10n == null ? fallback : pick(l10n);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _draftName = widget.initialName;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      key: const Key('notes_rename_node_dialog'),
+      title: Text(
+        _l10nText(
+          fallback: 'Rename',
+          pick: (l10n) => l10n.notesRenameDialogTitle,
+        ),
+      ),
+      content: TextFormField(
+        key: const Key('notes_rename_node_input'),
+        autofocus: true,
+        initialValue: widget.initialName,
+        onChanged: (value) {
+          setState(() {
+            _draftName = value;
+          });
+        },
+        onFieldSubmitted: (_) {
+          if (_canSubmit) {
+            widget.onConfirm(_draftName.trim());
+          }
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: widget.onCancel,
+          child: Text(
+            _l10nText(fallback: 'Cancel', pick: (l10n) => l10n.commonCancel),
+          ),
+        ),
+        FilledButton.tonal(
+          key: const Key('notes_rename_node_confirm_button'),
+          onPressed: _canSubmit
+              ? () {
+                  widget.onConfirm(_draftName.trim());
+                }
+              : null,
+          child: Text(
+            _l10nText(
+              fallback: 'Rename',
+              pick: (l10n) => l10n.notesRenameAction,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
+++ b/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
 import 'package:lazynote_flutter/features/notes/dialogs/create_folder_dialog.dart';
 import 'package:lazynote_flutter/features/notes/dialogs/delete_folder_dialog.dart';
+import 'package:lazynote_flutter/features/notes/dialogs/rename_node_dialog.dart';
 import 'package:lazynote_flutter/features/notes/explorer_context_menu.dart';
 import 'package:lazynote_flutter/features/notes/explorer_drag_controller.dart';
 import 'package:lazynote_flutter/features/notes/explorer_tree_item.dart';
@@ -1790,61 +1791,16 @@ class _NoteExplorerState extends State<NoteExplorer> {
       return;
     }
     final messenger = ScaffoldMessenger.maybeOf(context);
-    var draftName = node.displayName;
     final renamed = await showDialog<String>(
       context: context,
       builder: (dialogContext) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            final canSubmit =
-                draftName.trim().isNotEmpty &&
-                draftName.trim() != node.displayName.trim();
-            return AlertDialog(
-              key: const Key('notes_rename_node_dialog'),
-              title: Text(
-                _l10nText(
-                  fallback: 'Rename',
-                  pick: (l10n) => l10n.notesRenameDialogTitle,
-                ),
-              ),
-              content: TextFormField(
-                key: const Key('notes_rename_node_input'),
-                autofocus: true,
-                initialValue: node.displayName,
-                onChanged: (value) {
-                  draftName = value;
-                  setState(() {});
-                },
-                onFieldSubmitted: (_) {
-                  if (canSubmit) {
-                    Navigator.of(dialogContext).pop(draftName.trim());
-                  }
-                },
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(dialogContext).pop(),
-                  child: Text(
-                    _l10nText(
-                      fallback: 'Cancel',
-                      pick: (l10n) => l10n.commonCancel,
-                    ),
-                  ),
-                ),
-                FilledButton.tonal(
-                  key: const Key('notes_rename_node_confirm_button'),
-                  onPressed: canSubmit
-                      ? () => Navigator.of(dialogContext).pop(draftName.trim())
-                      : null,
-                  child: Text(
-                    _l10nText(
-                      fallback: 'Rename',
-                      pick: (l10n) => l10n.notesRenameAction,
-                    ),
-                  ),
-                ),
-              ],
-            );
+        return RenameNodeDialog(
+          initialName: node.displayName,
+          onConfirm: (value) {
+            Navigator.of(dialogContext).pop(value);
+          },
+          onCancel: () {
+            Navigator.of(dialogContext).pop();
           },
         );
       },

--- a/apps/lazynote_flutter/test/rename_node_dialog_test.dart
+++ b/apps/lazynote_flutter/test/rename_node_dialog_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lazynote_flutter/features/notes/dialogs/rename_node_dialog.dart';
+
+void main() {
+  Widget wrapWithMaterial(Widget child) {
+    return MaterialApp(home: Scaffold(body: child));
+  }
+
+  Future<void> openDialog(
+    WidgetTester tester, {
+    required RenameNodeDialogConfirm onConfirm,
+    required RenameNodeDialogCancel onCancel,
+  }) async {
+    await tester.pumpWidget(
+      wrapWithMaterial(
+        Builder(
+          builder: (context) => FilledButton(
+            key: const Key('open_rename_node_dialog'),
+            onPressed: () {
+              showDialog<void>(
+                context: context,
+                builder: (dialogContext) {
+                  return RenameNodeDialog(
+                    initialName: 'Inbox',
+                    onConfirm: (value) {
+                      onConfirm(value);
+                      Navigator.of(dialogContext).pop();
+                    },
+                    onCancel: () {
+                      onCancel();
+                      Navigator.of(dialogContext).pop();
+                    },
+                  );
+                },
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('open_rename_node_dialog')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('confirm is disabled when value is unchanged', (
+    WidgetTester tester,
+  ) async {
+    await openDialog(tester, onConfirm: (_) {}, onCancel: () {});
+
+    final confirmButton = tester.widget<FilledButton>(
+      find.byKey(const Key('notes_rename_node_confirm_button')),
+    );
+    expect(confirmButton.onPressed, isNull);
+  });
+
+  testWidgets('confirm submits trimmed renamed value', (
+    WidgetTester tester,
+  ) async {
+    String? renamedValue;
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        renamedValue = value;
+      },
+      onCancel: () {},
+    );
+
+    await tester.enterText(
+      find.byKey(const Key('notes_rename_node_input')),
+      '  Inbox Renamed  ',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('notes_rename_node_confirm_button')));
+    await tester.pumpAndSettle();
+
+    expect(renamedValue, 'Inbox Renamed');
+    expect(find.byKey(const Key('notes_rename_node_dialog')), findsNothing);
+  });
+
+  testWidgets('cancel and enter-submit both trigger callbacks', (
+    WidgetTester tester,
+  ) async {
+    var cancelCount = 0;
+    String? submittedValue;
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        submittedValue = value;
+      },
+      onCancel: () {
+        cancelCount += 1;
+      },
+    );
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(cancelCount, 1);
+
+    await openDialog(
+      tester,
+      onConfirm: (value) {
+        submittedValue = value;
+      },
+      onCancel: () {},
+    );
+    await tester.enterText(
+      find.byKey(const Key('notes_rename_node_input')),
+      '  Renamed by Enter  ',
+    );
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(submittedValue, 'Renamed by Enter');
+    expect(find.byKey(const Key('notes_rename_node_dialog')), findsNothing);
+  });
+}

--- a/docs/releases/v0.2.5/prs/PR-0252/P1-6-rename-node-dialog.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P1-6-rename-node-dialog.md
@@ -9,7 +9,7 @@
 | Branch | `feat/pr-0252-p1-6-rename-node-dialog` |
 | PR Title | `refactor(frontend): PR-0252 P1-6 extract rename node dialog` |
 | Estimated Effort | 0.5 person-day |
-| Status | Planned |
+| Status | Ready for Review |
 
 ## References
 
@@ -42,12 +42,13 @@ Out of scope:
 
 - [add] `apps/lazynote_flutter/lib/features/notes/dialogs/rename_node_dialog.dart`
 - [edit] `apps/lazynote_flutter/lib/features/notes/note_explorer.dart`
+- [add] `apps/lazynote_flutter/test/rename_node_dialog_test.dart`
 
 ## Acceptance Criteria
 
-- [ ] 独立 StatefulWidget，~130 行
-- [ ] CI 全绿
-- [ ] 测试基线不变（313 pass / 0 known-fail）
+- [x] 独立 StatefulWidget，~130 行
+- [x] CI 全绿
+- [x] 测试基线符合预期（主干 327 pass / 0 known-fail；本分支 330 pass / 0 known-fail，新增 3 个对话框测试）
 
 ## CI Gates
 
@@ -65,6 +66,14 @@ flutter build windows --debug
 |------|-------|----------|
 | D6 | `rg -n "import.*(coordinator|manager)" apps/lazynote_flutter/lib/features/notes/dialogs/` | 零匹配 |
 
+## Verification Snapshot (2026-02-25)
+
+- `flutter analyze`：通过（No issues found）
+- `flutter test test/rename_node_dialog_test.dart test/note_explorer_tree_test.dart test/notes_page_explorer_slot_wiring_test.dart`：通过
+- `flutter test`：通过（330 pass；相对主干 327 pass 增加 3 个对话框测试）
+- `flutter build windows --debug`：通过
+- D6：`rg -n "import.*(coordinator|manager)" apps/lazynote_flutter/lib/features/notes/dialogs/` 零匹配
+
 ## Regression
 
 - CI 自动回归
@@ -73,4 +82,3 @@ flutter build windows --debug
 ## Rollback
 
 独立 revert 即可。
-

--- a/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
+++ b/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
@@ -323,7 +323,7 @@
 | P1-3 | 提取 NoteTagManager | notes/managers | 结构拆分 | 无 | Agent | 1.5 | PR | 独立 ChangeNotifier，持有 noteSetTags + tagsList invoker，<350 行；标签变更队列独立；CI 全绿 | 已完成（2026-02-25） |
 | P1-4 | 提取 CreateFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行，接收回调参数；可独立 widget test；CI 全绿 | 已完成（2026-02-25） |
 | P1-5 | 提取 DeleteFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~150 行；含 dissolve/delete-all 选择；CI 全绿 | 已完成（2026-02-25） |
-| P1-6 | 提取 RenameNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行；CI 全绿 | 未开始 |
+| P1-6 | 提取 RenameNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行；CI 全绿 | 评审中（2026-02-25） |
 | P1-7 | 提取 MoveNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~160 行；含移动目标加载；CI 全绿 | 未开始 |
 | P1-8 | 提取 ExplorerTreeBuilder | notes | 结构拆分 | P1-4~7 | Agent | 1.0 | PR | 独立辅助类，<400 行，纯输入→输出；CI 全绿 | 未开始 |
 


### PR DESCRIPTION
**Title**  
`refactor(frontend): PR-0252 P1-6 extract rename node dialog`

**Description**  
Implements `PR-0252 / P1-6` by extracting the inline rename-node dialog from `NoteExplorer` into an independent widget.

### What changed
- Added `apps/lazynote_flutter/lib/features/notes/dialogs/rename_node_dialog.dart`
- Updated `apps/lazynote_flutter/lib/features/notes/note_explorer.dart` to use `RenameNodeDialog`
- Added independent widget tests in `apps/lazynote_flutter/test/rename_node_dialog_test.dart`
- Synced docs:
  - `docs/releases/v0.2.5/prs/PR-0252/P1-6-rename-node-dialog.md`
  - `docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md`

### Behavior/compatibility
- No intended behavior change in rename flow
- Existing dialog keys are preserved (`notes_rename_node_dialog`, `notes_rename_node_input`, `notes_rename_node_confirm_button`)
- Dialog communicates only via callbacks (`onConfirm`, `onCancel`) and does not import coordinator/manager (D6 compliant)

### Validation
- `flutter analyze` passed
- Targeted tests passed (rename dialog + explorer wiring paths)
- Full `flutter test` passed: **330 pass / 0 known-fail**
- `flutter build windows --debug` passed
- D6 check passed: zero `coordinator|manager` imports under `notes/dialogs/`