### PR TITLE
refactor(frontend): PR-0252 P1-8 extract explorer tree builder

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/explorer_tree_builder.dart
+++ b/apps/lazynote_flutter/lib/features/notes/explorer_tree_builder.dart
@@ -1,0 +1,391 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
+import 'package:lazynote_flutter/features/notes/explorer_tree_builder_types.dart';
+import 'package:lazynote_flutter/features/notes/explorer_tree_item.dart';
+import 'package:lazynote_flutter/features/notes/notes_style.dart';
+
+export 'package:lazynote_flutter/features/notes/explorer_tree_builder_types.dart'
+    show ExplorerFolderNode;
+
+class ExplorerTreeBuilder {
+  const ExplorerTreeBuilder({
+    required this.context,
+    required this.retryLabel,
+    required this.noItemsLabel,
+    required this.newChildFolderTooltip,
+    required this.deleteFolderTooltip,
+    required this.workspaceCreateFolderInFlight,
+    required this.workspaceDeleteInFlight,
+    required this.canCreateFolderAction,
+    required this.canDeleteFolderAction,
+    required this.activeNoteId,
+    required this.isExpanded,
+    required this.isLoading,
+    required this.errorMessageFor,
+    required this.hasLoaded,
+    required this.childrenFor,
+    required this.toggleFolder,
+    required this.retryParent,
+    required this.isSyntheticRootNodeId,
+    required this.looksLikeUuid,
+    required this.showCreateFolderDialog,
+    required this.showDeleteFolderDialog,
+    required this.recordRowContextMenuTrigger,
+    required this.showFolderContextMenu,
+    required this.showNoteContextMenu,
+    required this.wrapWorkspaceRowWithDrag,
+    required this.resolveNoteDisplayName,
+    required this.titleForTab,
+    required this.onNoteTap,
+  });
+
+  final BuildContext context;
+  final String retryLabel;
+  final String noItemsLabel;
+  final String newChildFolderTooltip;
+  final String deleteFolderTooltip;
+  final bool workspaceCreateFolderInFlight;
+  final bool workspaceDeleteInFlight;
+  final bool canCreateFolderAction;
+  final bool canDeleteFolderAction;
+  final String? activeNoteId;
+  final bool Function(String nodeId) isExpanded;
+  final bool Function(String nodeId) isLoading;
+  final String? Function(String nodeId) errorMessageFor;
+  final bool Function(String nodeId) hasLoaded;
+  final List<rust_api.WorkspaceNodeItem>? Function(String nodeId) childrenFor;
+  final Future<void> Function(String nodeId) toggleFolder;
+  final Future<void> Function(String? parentNodeId) retryParent;
+  final bool Function(String nodeId) isSyntheticRootNodeId;
+  final bool Function(String value) looksLikeUuid;
+  final Future<void> Function(String? parentNodeId) showCreateFolderDialog;
+  final Future<void> Function(ExplorerFolderNode node) showDeleteFolderDialog;
+  final void Function(Offset globalPosition) recordRowContextMenuTrigger;
+  final ExplorerWorkspaceFolderContextMenuInvoker showFolderContextMenu;
+  final ExplorerWorkspaceNoteContextMenuInvoker showNoteContextMenu;
+  final ExplorerWorkspaceDragWrapper wrapWorkspaceRowWithDrag;
+  final String Function(String noteId, rust_api.WorkspaceNodeItem node)
+  resolveNoteDisplayName;
+  final String Function(String noteId) titleForTab;
+  final void Function(String noteId) onNoteTap;
+
+  static List<ExplorerFolderNode> buildDefaultFolderTree({
+    required List<String> noteIds,
+    required String projectsLabel,
+    required String notesLabel,
+    required String personalLabel,
+  }) {
+    return <ExplorerFolderNode>[
+      ExplorerFolderNode(
+        id: 'projects',
+        label: projectsLabel,
+        deletable: false,
+      ),
+      ExplorerFolderNode(
+        id: 'notes',
+        label: notesLabel,
+        deletable: false,
+        noteIds: noteIds,
+      ),
+      ExplorerFolderNode(
+        id: 'personal',
+        label: personalLabel,
+        deletable: false,
+      ),
+    ];
+  }
+
+  void appendWorkspaceRows({
+    required List<Widget> rows,
+    required List<rust_api.WorkspaceNodeItem> items,
+    required int depth,
+  }) {
+    for (final item in items) {
+      if (item.kind == 'folder') {
+        final expanded = isExpanded(item.nodeId);
+        final loading = isLoading(item.nodeId);
+        final error = errorMessageFor(item.nodeId);
+        final isSyntheticRoot = isSyntheticRootNodeId(item.nodeId);
+        final canCreateChild =
+            canCreateFolderAction &&
+            (looksLikeUuid(item.nodeId) || isSyntheticRoot);
+        final canDelete = canDeleteFolderAction && looksLikeUuid(item.nodeId);
+        final folderRow = ExplorerTreeItem.folder(
+          key: Key('notes_tree_folder_row_${item.nodeId}'),
+          node: item,
+          depth: depth,
+          selected: false,
+          expanded: expanded,
+          canCreateChild: canCreateChild,
+          canDelete: canDelete,
+          onTap: () {
+            unawaited(toggleFolder(item.nodeId));
+          },
+          onCreateChildFolder: canCreateChild
+              ? workspaceCreateFolderInFlight
+                    ? null
+                    : () => unawaited(showCreateFolderDialog(item.nodeId))
+              : null,
+          onDeleteFolder: canDelete
+              ? () => unawaited(
+                  showDeleteFolderDialog(
+                    ExplorerFolderNode(
+                      id: item.nodeId,
+                      label: item.displayName,
+                      parentId: item.parentNodeId,
+                      deletable: true,
+                    ),
+                  ),
+                )
+              : null,
+          onSecondaryTapDown: (details) {
+            recordRowContextMenuTrigger(details.globalPosition);
+            unawaited(
+              showFolderContextMenu(
+                context: context,
+                folderNode: item,
+                globalPosition: details.globalPosition,
+              ),
+            );
+          },
+        );
+        rows.add(
+          wrapWorkspaceRowWithDrag(
+            context: context,
+            node: item,
+            depth: depth,
+            child: folderRow,
+          ),
+        );
+
+        if (!expanded) {
+          continue;
+        }
+        if (loading && !hasLoaded(item.nodeId)) {
+          rows.add(
+            Padding(
+              key: Key('notes_tree_loading_${item.nodeId}'),
+              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 4),
+              child: const SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(strokeWidth: 1.8),
+              ),
+            ),
+          );
+          continue;
+        }
+        if (error != null) {
+          rows.add(
+            Padding(
+              key: Key('notes_tree_error_${item.nodeId}'),
+              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 6),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      error,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.redAccent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    key: Key('notes_tree_retry_${item.nodeId}'),
+                    onPressed: () {
+                      unawaited(retryParent(item.nodeId));
+                    },
+                    child: Text(retryLabel),
+                  ),
+                ],
+              ),
+            ),
+          );
+          continue;
+        }
+        final children =
+            childrenFor(item.nodeId) ?? const <rust_api.WorkspaceNodeItem>[];
+        if (children.isEmpty) {
+          rows.add(
+            Padding(
+              key: Key('notes_tree_empty_${item.nodeId}'),
+              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 6),
+              child: Text(
+                noItemsLabel,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: kNotesSecondaryText),
+              ),
+            ),
+          );
+          continue;
+        }
+        appendWorkspaceRows(rows: rows, items: children, depth: depth + 1);
+        continue;
+      }
+
+      if (item.kind != 'note_ref') {
+        continue;
+      }
+      final noteId = item.atomId;
+      if (noteId == null || noteId.isEmpty) {
+        continue;
+      }
+      final displayName = resolveNoteDisplayName(noteId, item);
+      final noteRow = ExplorerTreeItem.note(
+        key: Key('notes_tree_note_row_${item.nodeId}'),
+        node: rust_api.WorkspaceNodeItem(
+          nodeId: item.nodeId,
+          kind: item.kind,
+          parentNodeId: item.parentNodeId,
+          atomId: item.atomId,
+          displayName: displayName,
+          sortOrder: item.sortOrder,
+        ),
+        depth: depth + 1,
+        selected: noteId == activeNoteId,
+        onTap: () => onNoteTap(noteId),
+        onSecondaryTapDown: (details) {
+          recordRowContextMenuTrigger(details.globalPosition);
+          unawaited(
+            showNoteContextMenu(
+              context: context,
+              noteNode: item,
+              globalPosition: details.globalPosition,
+            ),
+          );
+        },
+      );
+      rows.add(
+        wrapWorkspaceRowWithDrag(
+          context: context,
+          node: item,
+          depth: depth + 1,
+          child: noteRow,
+        ),
+      );
+    }
+  }
+
+  void appendLegacyFolderRows({
+    required List<Widget> rows,
+    required ExplorerFolderNode node,
+    required int depth,
+  }) {
+    final canDelete =
+        canDeleteFolderAction && node.deletable && looksLikeUuid(node.id);
+    final canCreateChild = canCreateFolderAction && looksLikeUuid(node.id);
+    rows.add(
+      Padding(
+        padding: EdgeInsets.fromLTRB(12 + depth * 12, 8, 10, 2),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.chevron_right,
+              size: 14,
+              color: kNotesSecondaryText,
+            ),
+            const SizedBox(width: 2),
+            Icon(Icons.folder_outlined, size: 16, color: kNotesSecondaryText),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                node.label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: kNotesSecondaryText,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            if (canCreateChild)
+              IconButton(
+                key: Key('notes_folder_create_button_${node.id}'),
+                tooltip: newChildFolderTooltip,
+                onPressed: workspaceCreateFolderInFlight
+                    ? null
+                    : () => unawaited(showCreateFolderDialog(node.id)),
+                constraints: const BoxConstraints.tightFor(
+                  width: 22,
+                  height: 22,
+                ),
+                padding: EdgeInsets.zero,
+                visualDensity: VisualDensity.compact,
+                icon: workspaceCreateFolderInFlight
+                    ? const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 1.4,
+                          color: kNotesSecondaryText,
+                        ),
+                      )
+                    : const Icon(
+                        Icons.create_new_folder_outlined,
+                        size: 14,
+                        color: kNotesSecondaryText,
+                      ),
+              ),
+            if (canDelete)
+              IconButton(
+                key: Key('notes_folder_delete_button_${node.id}'),
+                tooltip: deleteFolderTooltip,
+                onPressed: workspaceDeleteInFlight
+                    ? null
+                    : () => unawaited(showDeleteFolderDialog(node)),
+                constraints: const BoxConstraints.tightFor(
+                  width: 22,
+                  height: 22,
+                ),
+                padding: EdgeInsets.zero,
+                visualDensity: VisualDensity.compact,
+                icon: workspaceDeleteInFlight
+                    ? const SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 1.4,
+                          color: kNotesSecondaryText,
+                        ),
+                      )
+                    : const Icon(
+                        Icons.delete_outline,
+                        size: 14,
+                        color: kNotesSecondaryText,
+                      ),
+              ),
+          ],
+        ),
+      ),
+    );
+
+    for (final child in node.children) {
+      appendLegacyFolderRows(rows: rows, node: child, depth: depth + 1);
+    }
+
+    for (final noteId in node.noteIds) {
+      rows.add(
+        ExplorerTreeItem.note(
+          key: Key('notes_tree_legacy_note_row_$noteId'),
+          node: rust_api.WorkspaceNodeItem(
+            nodeId: 'legacy_note_$noteId',
+            kind: 'note_ref',
+            parentNodeId: node.id,
+            atomId: noteId,
+            displayName: titleForTab(noteId),
+            sortOrder: 0,
+          ),
+          selected: noteId == activeNoteId,
+          depth: depth + 1,
+          onTap: () => onNoteTap(noteId),
+        ),
+      );
+    }
+  }
+}

--- a/apps/lazynote_flutter/lib/features/notes/explorer_tree_builder_types.dart
+++ b/apps/lazynote_flutter/lib/features/notes/explorer_tree_builder_types.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
+
+class ExplorerFolderNode {
+  const ExplorerFolderNode({
+    required this.id,
+    required this.label,
+    this.parentId,
+    this.children = const <ExplorerFolderNode>[],
+    this.noteIds = const <String>[],
+    this.deletable = true,
+  });
+
+  final String id;
+  final String label;
+  final String? parentId;
+  final List<ExplorerFolderNode> children;
+  final List<String> noteIds;
+  final bool deletable;
+}
+
+typedef ExplorerWorkspaceFolderContextMenuInvoker =
+    Future<void> Function({
+      required BuildContext context,
+      required rust_api.WorkspaceNodeItem folderNode,
+      required Offset globalPosition,
+    });
+
+typedef ExplorerWorkspaceNoteContextMenuInvoker =
+    Future<void> Function({
+      required BuildContext context,
+      required rust_api.WorkspaceNodeItem noteNode,
+      required Offset globalPosition,
+    });
+
+typedef ExplorerWorkspaceDragWrapper =
+    Widget Function({
+      required BuildContext context,
+      required rust_api.WorkspaceNodeItem node,
+      required int depth,
+      required Widget child,
+    });

--- a/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
+++ b/apps/lazynote_flutter/lib/features/notes/note_explorer.dart
@@ -9,42 +9,15 @@ import 'package:lazynote_flutter/features/notes/dialogs/move_node_dialog.dart';
 import 'package:lazynote_flutter/features/notes/dialogs/rename_node_dialog.dart';
 import 'package:lazynote_flutter/features/notes/explorer_context_menu.dart';
 import 'package:lazynote_flutter/features/notes/explorer_drag_controller.dart';
-import 'package:lazynote_flutter/features/notes/explorer_tree_item.dart';
+import 'package:lazynote_flutter/features/notes/explorer_tree_builder.dart';
 import 'package:lazynote_flutter/features/notes/explorer_tree_state.dart';
 import 'package:lazynote_flutter/features/notes/notes_controller.dart';
 import 'package:lazynote_flutter/features/notes/notes_style.dart';
 import 'package:lazynote_flutter/features/tags/tag_filter.dart';
 import 'package:lazynote_flutter/l10n/app_localizations.dart';
 
-/// Folder node model reserved for hierarchical explorer expansion.
-class ExplorerFolderNode {
-  const ExplorerFolderNode({
-    required this.id,
-    required this.label,
-    this.parentId,
-    this.children = const <ExplorerFolderNode>[],
-    this.noteIds = const <String>[],
-    this.deletable = true,
-  });
-
-  /// Stable node id used by future tree operations.
-  final String id;
-
-  /// Display label rendered in explorer tree.
-  final String label;
-
-  /// Parent node id when sourced from workspace tree (nullable for root).
-  final String? parentId;
-
-  /// Recursive child folders (v0.1 currently one-level usage).
-  final List<ExplorerFolderNode> children;
-
-  /// Note ids attached to this folder node.
-  final List<String> noteIds;
-
-  /// Whether this folder should expose delete action in explorer UI.
-  final bool deletable;
-}
+export 'package:lazynote_flutter/features/notes/explorer_tree_builder.dart'
+    show ExplorerFolderNode;
 
 /// Async folder-delete callback from explorer to controller layer.
 typedef ExplorerFolderDeleteInvoker =
@@ -504,9 +477,10 @@ class _NoteExplorerState extends State<NoteExplorer> {
   Widget _buildSuccessTree(BuildContext context) {
     if (widget.folderTreeBuilder != null) {
       final rows = <Widget>[_buildTagFilter()];
+      final treeBuilder = _createTreeBuilder(context);
       final tree = _buildFolderTree();
       for (final node in tree) {
-        _appendLegacyFolderRows(context, rows: rows, node: node, depth: 0);
+        treeBuilder.appendLegacyFolderRows(rows: rows, node: node, depth: 0);
       }
       return _buildScrollableRows(rows);
     }
@@ -514,6 +488,7 @@ class _NoteExplorerState extends State<NoteExplorer> {
     return AnimatedBuilder(
       animation: Listenable.merge([_treeState, widget.controller]),
       builder: (context, _) {
+        final treeBuilder = _createTreeBuilder(context);
         final rows = <Widget>[_buildTagFilter()];
         if (_treeState.isLoading(null) && !_treeState.hasLoaded(null)) {
           rows.add(
@@ -590,9 +565,66 @@ class _NoteExplorerState extends State<NoteExplorer> {
         if (_dragInProgress && widget.onMoveNodeRequested != null) {
           rows.add(_buildRootDropLane(context));
         }
-        _appendWorkspaceRows(context, rows: rows, items: rootItems, depth: 0);
+        treeBuilder.appendWorkspaceRows(rows: rows, items: rootItems, depth: 0);
         return _buildScrollableRows(rows);
       },
+    );
+  }
+
+  ExplorerTreeBuilder _createTreeBuilder(BuildContext context) {
+    return ExplorerTreeBuilder(
+      context: context,
+      retryLabel: _l10nText(
+        fallback: 'Retry',
+        pick: (l10n) => l10n.retryButton,
+      ),
+      noItemsLabel: _l10nText(
+        fallback: 'No items',
+        pick: (l10n) => l10n.notesNoItemsLabel,
+      ),
+      newChildFolderTooltip: _l10nText(
+        fallback: 'New child folder',
+        pick: (l10n) => l10n.notesNewChildFolderTooltip,
+      ),
+      deleteFolderTooltip: _l10nText(
+        fallback: 'Delete folder',
+        pick: (l10n) => l10n.notesDeleteFolderTooltip,
+      ),
+      workspaceCreateFolderInFlight:
+          widget.controller.workspaceCreateFolderInFlight,
+      workspaceDeleteInFlight: widget.controller.workspaceDeleteInFlight,
+      canCreateFolderAction: widget.onCreateFolderRequested != null,
+      canDeleteFolderAction: widget.onDeleteFolderRequested != null,
+      activeNoteId: widget.controller.activeNoteId,
+      isExpanded: _treeState.isExpanded,
+      isLoading: _treeState.isLoading,
+      errorMessageFor: _treeState.errorMessageFor,
+      hasLoaded: _treeState.hasLoaded,
+      childrenFor: _treeState.childrenFor,
+      toggleFolder: _treeState.toggleFolder,
+      retryParent: _treeState.retryParent,
+      isSyntheticRootNodeId: _isSyntheticRootNodeId,
+      looksLikeUuid: _looksLikeUuid,
+      showCreateFolderDialog: (parentNodeId) =>
+          _showCreateFolderDialog(context, parentNodeId: parentNodeId),
+      showDeleteFolderDialog: (node) => _showDeleteFolderDialog(context, node),
+      recordRowContextMenuTrigger: _recordRowContextMenuTrigger,
+      showFolderContextMenu: _showFolderContextMenu,
+      showNoteContextMenu: _showNoteContextMenu,
+      wrapWorkspaceRowWithDrag: _wrapWorkspaceRowWithDrag,
+      resolveNoteDisplayName: (noteId, item) {
+        final note = widget.controller.noteById(noteId);
+        final projectedTitle = note == null
+            ? null
+            : widget.controller.titleForTab(noteId);
+        final trimmedNodeLabel = item.displayName.trim();
+        return projectedTitle ??
+            (trimmedNodeLabel.isEmpty
+                ? widget.controller.titleForTab(noteId)
+                : item.displayName);
+      },
+      titleForTab: widget.controller.titleForTab,
+      onNoteTap: _handleNoteTap,
     );
   }
 
@@ -1194,380 +1226,26 @@ class _NoteExplorerState extends State<NoteExplorer> {
     }
   }
 
-  void _appendWorkspaceRows(
-    BuildContext context, {
-    required List<Widget> rows,
-    required List<rust_api.WorkspaceNodeItem> items,
-    required int depth,
-  }) {
-    for (final item in items) {
-      if (item.kind == 'folder') {
-        final expanded = _treeState.isExpanded(item.nodeId);
-        final loading = _treeState.isLoading(item.nodeId);
-        final error = _treeState.errorMessageFor(item.nodeId);
-        final isSyntheticRoot = _isSyntheticRootNodeId(item.nodeId);
-        final canCreateChild =
-            widget.onCreateFolderRequested != null &&
-            (_looksLikeUuid(item.nodeId) || isSyntheticRoot);
-        final canDelete =
-            widget.onDeleteFolderRequested != null &&
-            _looksLikeUuid(item.nodeId);
-        final folderRow = ExplorerTreeItem.folder(
-          key: Key('notes_tree_folder_row_${item.nodeId}'),
-          node: item,
-          depth: depth,
-          selected: false,
-          expanded: expanded,
-          canCreateChild: canCreateChild,
-          canDelete: canDelete,
-          onTap: () {
-            unawaited(_treeState.toggleFolder(item.nodeId));
-          },
-          onCreateChildFolder: canCreateChild
-              ? widget.controller.workspaceCreateFolderInFlight
-                    ? null
-                    : () => _showCreateFolderDialog(
-                        context,
-                        parentNodeId: item.nodeId,
-                      )
-              : null,
-          onDeleteFolder: canDelete
-              ? () => _showDeleteFolderDialog(
-                  context,
-                  ExplorerFolderNode(
-                    id: item.nodeId,
-                    label: item.displayName,
-                    parentId: item.parentNodeId,
-                    deletable: true,
-                  ),
-                )
-              : null,
-          onSecondaryTapDown: (details) {
-            _recordRowContextMenuTrigger(details.globalPosition);
-            unawaited(
-              _showFolderContextMenu(
-                context: context,
-                folderNode: item,
-                globalPosition: details.globalPosition,
-              ),
-            );
-          },
-        );
-        rows.add(
-          _wrapWorkspaceRowWithDrag(
-            context: context,
-            node: item,
-            depth: depth,
-            child: folderRow,
-          ),
-        );
-
-        if (!expanded) {
-          continue;
-        }
-        if (loading && !_treeState.hasLoaded(item.nodeId)) {
-          rows.add(
-            Padding(
-              key: Key('notes_tree_loading_${item.nodeId}'),
-              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 4),
-              child: const SizedBox(
-                width: 14,
-                height: 14,
-                child: CircularProgressIndicator(strokeWidth: 1.8),
-              ),
-            ),
-          );
-          continue;
-        }
-        if (error != null) {
-          rows.add(
-            Padding(
-              key: Key('notes_tree_error_${item.nodeId}'),
-              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 6),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      error,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Colors.redAccent,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                  TextButton(
-                    key: Key('notes_tree_retry_${item.nodeId}'),
-                    onPressed: () {
-                      unawaited(_treeState.retryParent(item.nodeId));
-                    },
-                    child: Text(
-                      _l10nText(
-                        fallback: 'Retry',
-                        pick: (l10n) => l10n.retryButton,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          );
-          continue;
-        }
-        final children =
-            _treeState.childrenFor(item.nodeId) ??
-            const <rust_api.WorkspaceNodeItem>[];
-        if (children.isEmpty) {
-          rows.add(
-            Padding(
-              key: Key('notes_tree_empty_${item.nodeId}'),
-              padding: EdgeInsets.fromLTRB(30 + depth * 12, 2, 10, 6),
-              child: Text(
-                _l10nText(
-                  fallback: 'No items',
-                  pick: (l10n) => l10n.notesNoItemsLabel,
-                ),
-                style: Theme.of(
-                  context,
-                ).textTheme.bodySmall?.copyWith(color: kNotesSecondaryText),
-              ),
-            ),
-          );
-          continue;
-        }
-        _appendWorkspaceRows(
-          context,
-          rows: rows,
-          items: children,
-          depth: depth + 1,
-        );
-        continue;
-      }
-
-      if (item.kind != 'note_ref') {
-        continue;
-      }
-      final noteId = item.atomId;
-      if (noteId == null || noteId.isEmpty) {
-        continue;
-      }
-      final note = widget.controller.noteById(noteId);
-      // Keep note-row title projection unified across folders/uncategorized.
-      // Fallback to node label only when note snapshot is unavailable.
-      final projectedTitle = note == null
-          ? null
-          : widget.controller.titleForTab(noteId);
-      final trimmedNodeLabel = item.displayName.trim();
-      final displayName =
-          projectedTitle ??
-          (trimmedNodeLabel.isEmpty
-              ? widget.controller.titleForTab(noteId)
-              : item.displayName);
-      final noteRow = ExplorerTreeItem.note(
-        key: Key('notes_tree_note_row_${item.nodeId}'),
-        node: rust_api.WorkspaceNodeItem(
-          nodeId: item.nodeId,
-          kind: item.kind,
-          parentNodeId: item.parentNodeId,
-          atomId: item.atomId,
-          displayName: displayName,
-          sortOrder: item.sortOrder,
-        ),
-        depth: depth + 1,
-        selected: noteId == widget.controller.activeNoteId,
-        onTap: () => _handleNoteTap(noteId),
-        onSecondaryTapDown: (details) {
-          _recordRowContextMenuTrigger(details.globalPosition);
-          unawaited(
-            _showNoteContextMenu(
-              context: context,
-              noteNode: item,
-              globalPosition: details.globalPosition,
-            ),
-          );
-        },
-      );
-      rows.add(
-        _wrapWorkspaceRowWithDrag(
-          context: context,
-          node: item,
-          depth: depth + 1,
-          child: noteRow,
-        ),
-      );
-    }
-  }
-
   List<ExplorerFolderNode> _buildFolderTree() {
     if (widget.folderTreeBuilder case final builder?) {
       return builder(widget.controller);
     }
-    // v0.2A visual baseline: show workspace-like top folders while still
-    // binding note rows from existing list source.
     final noteIds = widget.controller.items.map((item) => item.atomId).toList();
-    return <ExplorerFolderNode>[
-      ExplorerFolderNode(
-        id: 'projects',
-        label: _l10nText(
-          fallback: 'Projects',
-          pick: (l10n) => l10n.notesLegacyFolderProjects,
-        ),
-        deletable: false,
+    return ExplorerTreeBuilder.buildDefaultFolderTree(
+      noteIds: noteIds,
+      projectsLabel: _l10nText(
+        fallback: 'Projects',
+        pick: (l10n) => l10n.notesLegacyFolderProjects,
       ),
-      ExplorerFolderNode(
-        id: 'notes',
-        label: _l10nText(
-          fallback: 'Notes',
-          pick: (l10n) => l10n.workbenchSectionNotes,
-        ),
-        deletable: false,
-        noteIds: noteIds,
+      notesLabel: _l10nText(
+        fallback: 'Notes',
+        pick: (l10n) => l10n.workbenchSectionNotes,
       ),
-      ExplorerFolderNode(
-        id: 'personal',
-        label: _l10nText(
-          fallback: 'Personal',
-          pick: (l10n) => l10n.notesLegacyFolderPersonal,
-        ),
-        deletable: false,
-      ),
-    ];
-  }
-
-  void _appendLegacyFolderRows(
-    BuildContext context, {
-    required List<Widget> rows,
-    required ExplorerFolderNode node,
-    required int depth,
-  }) {
-    final canDelete =
-        widget.onDeleteFolderRequested != null &&
-        node.deletable &&
-        _looksLikeUuid(node.id);
-    final canCreateChild =
-        widget.onCreateFolderRequested != null && _looksLikeUuid(node.id);
-    rows.add(
-      Padding(
-        padding: EdgeInsets.fromLTRB(12 + depth * 12, 8, 10, 2),
-        child: Row(
-          children: [
-            const Icon(
-              Icons.chevron_right,
-              size: 14,
-              color: kNotesSecondaryText,
-            ),
-            const SizedBox(width: 2),
-            Icon(Icons.folder_outlined, size: 16, color: kNotesSecondaryText),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                node.label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: kNotesSecondaryText,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-            if (canCreateChild)
-              IconButton(
-                key: Key('notes_folder_create_button_${node.id}'),
-                tooltip: _l10nText(
-                  fallback: 'New child folder',
-                  pick: (l10n) => l10n.notesNewChildFolderTooltip,
-                ),
-                onPressed: widget.controller.workspaceCreateFolderInFlight
-                    ? null
-                    : () => _showCreateFolderDialog(
-                        context,
-                        parentNodeId: node.id,
-                      ),
-                constraints: const BoxConstraints.tightFor(
-                  width: 22,
-                  height: 22,
-                ),
-                padding: EdgeInsets.zero,
-                visualDensity: VisualDensity.compact,
-                icon: widget.controller.workspaceCreateFolderInFlight
-                    ? const SizedBox(
-                        width: 12,
-                        height: 12,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 1.4,
-                          color: kNotesSecondaryText,
-                        ),
-                      )
-                    : const Icon(
-                        Icons.create_new_folder_outlined,
-                        size: 14,
-                        color: kNotesSecondaryText,
-                      ),
-              ),
-            if (canDelete)
-              IconButton(
-                key: Key('notes_folder_delete_button_${node.id}'),
-                tooltip: _l10nText(
-                  fallback: 'Delete folder',
-                  pick: (l10n) => l10n.notesDeleteFolderTooltip,
-                ),
-                onPressed: widget.controller.workspaceDeleteInFlight
-                    ? null
-                    : () => _showDeleteFolderDialog(context, node),
-                constraints: const BoxConstraints.tightFor(
-                  width: 22,
-                  height: 22,
-                ),
-                padding: EdgeInsets.zero,
-                visualDensity: VisualDensity.compact,
-                icon: widget.controller.workspaceDeleteInFlight
-                    ? const SizedBox(
-                        width: 12,
-                        height: 12,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 1.4,
-                          color: kNotesSecondaryText,
-                        ),
-                      )
-                    : const Icon(
-                        Icons.delete_outline,
-                        size: 14,
-                        color: kNotesSecondaryText,
-                      ),
-              ),
-          ],
-        ),
+      personalLabel: _l10nText(
+        fallback: 'Personal',
+        pick: (l10n) => l10n.notesLegacyFolderPersonal,
       ),
     );
-
-    for (final child in node.children) {
-      _appendLegacyFolderRows(
-        context,
-        rows: rows,
-        node: child,
-        depth: depth + 1,
-      );
-    }
-
-    for (final noteId in node.noteIds) {
-      rows.add(
-        ExplorerTreeItem.note(
-          key: Key('notes_tree_legacy_note_row_$noteId'),
-          node: rust_api.WorkspaceNodeItem(
-            nodeId: 'legacy_note_$noteId',
-            kind: 'note_ref',
-            parentNodeId: node.id,
-            atomId: noteId,
-            displayName: widget.controller.titleForTab(noteId),
-            sortOrder: 0,
-          ),
-          selected: noteId == widget.controller.activeNoteId,
-          depth: depth + 1,
-          onTap: () => _handleNoteTap(noteId),
-        ),
-      );
-    }
   }
 
   bool _looksLikeUuid(String value) {

--- a/docs/releases/v0.2.5/prs/PR-0252/P1-8-explorer-tree-builder.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P1-8-explorer-tree-builder.md
@@ -9,7 +9,7 @@
 | Branch | `feat/pr-0252-p1-8-explorer-tree-builder` |
 | PR Title | `refactor(frontend): PR-0252 P1-8 extract explorer tree builder` |
 | Estimated Effort | 1.0 person-day |
-| Status | Planned |
+| Status | Ready for Review |
 
 ## References
 
@@ -45,14 +45,15 @@ Out of scope:
 ## Planned File Changes
 
 - [add] `apps/lazynote_flutter/lib/features/notes/explorer_tree_builder.dart`
+- [add] `apps/lazynote_flutter/lib/features/notes/explorer_tree_builder_types.dart`
 - [edit] `apps/lazynote_flutter/lib/features/notes/note_explorer.dart` (import extracted builder)
 
 ## Acceptance Criteria
 
-- [ ] 独立辅助类，<400 行
-- [ ] 纯输入→输出
-- [ ] CI 全绿
-- [ ] 测试基线不变（313 pass / 0 known-fail）
+- [x] 独立辅助类，<400 行（`explorer_tree_builder.dart` 物理行 391）
+- [x] 纯输入→输出
+- [x] CI 全绿
+- [x] 测试基线不变（主干 333 pass / 0 known-fail；本分支 333 pass / 0 known-fail）
 
 ## CI Gates
 
@@ -70,6 +71,15 @@ flutter build windows --debug
 - 不 import `features/workspace/` 内部文件（D7 精神）
 - 不 import coordinator/manager（非 UI 组件不应持有 controller 引用）
 
+## Verification Snapshot (2026-02-25)
+
+- `dart format apps/lazynote_flutter/lib/features/notes/explorer_tree_builder.dart apps/lazynote_flutter/lib/features/notes/explorer_tree_builder_types.dart apps/lazynote_flutter/lib/features/notes/note_explorer.dart`：通过
+- `flutter analyze`：通过（No issues found）
+- `flutter test test/note_explorer_tree_test.dart test/note_explorer_workspace_delete_test.dart test/explorer_context_actions_test.dart test/notes_page_explorer_slot_wiring_test.dart`：通过
+- `flutter test`：通过（333 pass，基线不变）
+- `flutter build windows --debug`：通过
+- 依赖边界检查：`features/workspace` 零匹配；`coordinator|manager` import 零匹配
+
 ## Regression
 
 - CI 自动回归
@@ -79,4 +89,3 @@ flutter build windows --debug
 ## Rollback
 
 独立 revert 即可。删除 `explorer_tree_builder.dart`，回退 `note_explorer.dart` 的 import 改动。
-

--- a/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
+++ b/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
@@ -325,7 +325,7 @@
 | P1-5 | 提取 DeleteFolderDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~150 行；含 dissolve/delete-all 选择；CI 全绿 | 已完成（2026-02-25） |
 | P1-6 | 提取 RenameNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~130 行；CI 全绿 | 已完成（2026-02-25） |
 | P1-7 | 提取 MoveNodeDialog | notes/dialogs | 结构拆分 | 无 | Agent | 0.5 | PR | 独立 StatefulWidget，~160 行；含移动目标加载；CI 全绿 | 已完成（2026-02-25） |
-| P1-8 | 提取 ExplorerTreeBuilder | notes | 结构拆分 | P1-4~7 | Agent | 1.0 | PR | 独立辅助类，<400 行，纯输入→输出；CI 全绿 | 未开始 |
+| P1-8 | 提取 ExplorerTreeBuilder | notes | 结构拆分 | P1-4~7 | Agent | 1.0 | PR | 独立辅助类，<400 行，纯输入→输出；CI 全绿 | 评审中（2026-02-25） |
 
 #### Phase 2 任务（中等/多孔域 + Coordinator 切换）
 
@@ -923,7 +923,7 @@ Phase 3 验收通过后，输出以下收口产物：
 | 10 | DeleteFolderDialog | `note_explorer.dart` | `notes/dialogs/delete_folder_dialog.dart` | ~150 | — | 已完成（P1-5） |
 | 11 | RenameNodeDialog | `note_explorer.dart` | `notes/dialogs/rename_node_dialog.dart` | ~130 | — | 已完成（P1-6） |
 | 12 | MoveNodeDialog | `note_explorer.dart` | `notes/dialogs/move_node_dialog.dart` | ~160 | — | 已完成（P1-7） |
-| 13 | ExplorerTreeBuilder | `note_explorer.dart` | `notes/explorer_tree_builder.dart` | <400 | — | 待执行 |
+| 13 | ExplorerTreeBuilder | `note_explorer.dart` | `notes/explorer_tree_builder.dart` | <400 | — | 评审中（P1-8） |
 | 14 | SectionRegistry | `entry_shell_page.dart` | `app/section_registry.dart` | — | — | 待执行 |
 
 #### 11.2.2 未完成项与原因（收口时填写）


### PR DESCRIPTION
**Title**  
`refactor(frontend): PR-0252 P1-8 extract explorer tree builder`

**Description**  
This PR implements `PR-0252 / P1-8` by extracting NoteExplorer tree rendering into a dedicated, stateless helper while preserving behavior.

## Scope
- Added `apps/lazynote_flutter/lib/features/notes/explorer_tree_builder.dart` (render helper, pure input -> output).
- Added `apps/lazynote_flutter/lib/features/notes/explorer_tree_builder_types.dart` (`ExplorerFolderNode` and related typedefs).
- Updated `apps/lazynote_flutter/lib/features/notes/note_explorer.dart` to delegate tree row construction to `ExplorerTreeBuilder`.
- Updated docs:
  - `docs/releases/v0.2.5/prs/PR-0252/P1-8-explorer-tree-builder.md`
  - `docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md`

## Behavior Parity
- No product behavior changes intended.
- Existing explorer interactions, keys, and action flows remain unchanged.
- Refactor only: logic relocation and structural decoupling.

## Validation
- `flutter analyze` passed.
- Targeted explorer regression suite passed.
- `flutter test` passed (`333` total, baseline unchanged).
- `flutter build windows --debug` passed.
- Boundary checks passed (no `features/workspace` import; no `coordinator|manager` imports in builder files).

## Review Note
- `ExplorerTreeBuilder` currently has 28 constructor parameters.
- This is accepted for Phase 1 as a non-blocking tradeoff for strict behavior parity and stateless extraction.