### PR TITLE
refactor(frontend): PR-0252 P2-2 extract note list manager

### DIFF
--- a/apps/lazynote_flutter/lib/features/notes/managers/note_list_manager.dart
+++ b/apps/lazynote_flutter/lib/features/notes/managers/note_list_manager.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/foundation.dart';
+import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
+
+typedef NoteListNotesListInvoker =
+    Future<rust_api.NotesListResponse> Function({
+      String? tag,
+      int? limit,
+      int? offset,
+    });
+
+typedef NoteListNoteGetInvoker =
+    Future<rust_api.NoteResponse> Function({required String atomId});
+
+typedef NoteListPrepare = Future<void> Function();
+
+typedef NoteListEnvelopeError =
+    String Function({
+      required String? errorCode,
+      required String message,
+      required String fallback,
+    });
+
+typedef NoteListSelectedTagReader = String? Function();
+
+typedef NoteListShouldIncludeInVisibleList =
+    bool Function(rust_api.NoteItem note);
+
+typedef NoteListIsDirty = bool Function(String atomId);
+
+typedef NoteListSyncPersistedSnapshot =
+    void Function({
+      required String atomId,
+      required String content,
+      required bool wasDirty,
+    });
+
+enum NotesListPhase { idle, loading, success, empty, error }
+
+class NoteListManager extends ChangeNotifier {
+  NoteListManager({
+    required NoteListNotesListInvoker notesListInvoker,
+    required NoteListNoteGetInvoker noteGetInvoker,
+    required NoteListPrepare prepare,
+    required NoteListEnvelopeError envelopeError,
+    required NoteListSelectedTagReader selectedTag,
+    required NoteListShouldIncludeInVisibleList shouldIncludeInVisibleList,
+    required NoteListIsDirty isDirty,
+    required NoteListSyncPersistedSnapshot syncPersistedSnapshot,
+  }) : _notesListInvoker = notesListInvoker,
+       _noteGetInvoker = noteGetInvoker,
+       _prepare = prepare,
+       _envelopeError = envelopeError,
+       _selectedTag = selectedTag,
+       _shouldIncludeInVisibleList = shouldIncludeInVisibleList,
+       _isDirty = isDirty,
+       _syncPersistedSnapshot = syncPersistedSnapshot;
+
+  final NoteListNotesListInvoker _notesListInvoker;
+  final NoteListNoteGetInvoker _noteGetInvoker;
+  final NoteListPrepare _prepare;
+  final NoteListEnvelopeError _envelopeError;
+  final NoteListSelectedTagReader _selectedTag;
+  final NoteListShouldIncludeInVisibleList _shouldIncludeInVisibleList;
+  final NoteListIsDirty _isDirty;
+  final NoteListSyncPersistedSnapshot _syncPersistedSnapshot;
+
+  NotesListPhase _listPhase = NotesListPhase.idle;
+  List<rust_api.NoteItem> _items = const [];
+  String? _listErrorMessage;
+  int _listRequestId = 0;
+  final Map<String, rust_api.NoteItem> _noteCache =
+      <String, rust_api.NoteItem>{};
+
+  NotesListPhase get listPhase => _listPhase;
+  List<rust_api.NoteItem> get items => List.unmodifiable(_items);
+  String? get listErrorMessage => _listErrorMessage;
+
+  rust_api.NoteItem? noteById(String atomId) {
+    return _noteCache[atomId] ?? findListItem(atomId);
+  }
+
+  rust_api.NoteItem? cachedNoteById(String atomId) => _noteCache[atomId];
+
+  rust_api.NoteItem? findListItem(String atomId) {
+    for (final item in _items) {
+      if (item.atomId == atomId) {
+        return item;
+      }
+    }
+    return null;
+  }
+
+  rust_api.NoteItem? findLoadedItem(
+    List<rust_api.NoteItem> items,
+    String atomId,
+  ) {
+    for (final item in items) {
+      if (item.atomId == atomId) {
+        return item;
+      }
+    }
+    return null;
+  }
+
+  void markListSuccess({bool notify = false}) {
+    _listPhase = _items.isEmpty ? NotesListPhase.empty : NotesListPhase.success;
+    if (notify) {
+      notifyListeners();
+    }
+  }
+
+  void resetSessionState({bool notify = false}) {
+    _listRequestId += 1;
+    _listPhase = NotesListPhase.idle;
+    _items = const [];
+    _listErrorMessage = null;
+    _noteCache.clear();
+    if (notify) {
+      notifyListeners();
+    }
+  }
+
+  void evictNoteState(String atomId) {
+    _noteCache.remove(atomId);
+  }
+
+  void upsertNote(
+    rust_api.NoteItem note, {
+    bool insertFront = false,
+    bool updatePersisted = false,
+    bool syncVisibleList = true,
+  }) {
+    final wasDirty = _isDirty(note.atomId);
+    _noteCache[note.atomId] = note;
+    if (updatePersisted) {
+      _syncPersistedSnapshot(
+        atomId: note.atomId,
+        content: note.content,
+        wasDirty: wasDirty,
+      );
+    }
+    if (!syncVisibleList) {
+      return;
+    }
+
+    final includeInVisibleList = _shouldIncludeInVisibleList(note);
+    final mutable = List<rust_api.NoteItem>.from(_items);
+    final existingIndex = mutable.indexWhere(
+      (item) => item.atomId == note.atomId,
+    );
+    if (includeInVisibleList) {
+      if (existingIndex >= 0) {
+        mutable[existingIndex] = note;
+      } else if (insertFront) {
+        mutable.insert(0, note);
+      } else {
+        mutable.add(note);
+      }
+    } else if (existingIndex >= 0) {
+      mutable.removeAt(existingIndex);
+    }
+    _items = List<rust_api.NoteItem>.unmodifiable(mutable);
+  }
+
+  Future<List<rust_api.NoteItem>?> loadNotes({
+    required int limit,
+    int offset = 0,
+  }) async {
+    final requestId = ++_listRequestId;
+    _listPhase = NotesListPhase.loading;
+    _items = const [];
+    _listErrorMessage = null;
+    notifyListeners();
+
+    try {
+      await _prepare();
+      if (requestId != _listRequestId) {
+        return null;
+      }
+
+      final response = await _notesListInvoker(
+        tag: _selectedTag(),
+        limit: limit,
+        offset: offset,
+      );
+      if (requestId != _listRequestId) {
+        return null;
+      }
+
+      if (!response.ok) {
+        _listPhase = NotesListPhase.error;
+        _listErrorMessage = _envelopeError(
+          errorCode: response.errorCode,
+          message: response.message,
+          fallback: 'Failed to load notes.',
+        );
+        notifyListeners();
+        return null;
+      }
+
+      final loadedItems = List<rust_api.NoteItem>.unmodifiable(response.items);
+      _items = loadedItems;
+      for (final item in loadedItems) {
+        // Keep visible list as returned by backend filter; only refresh cache.
+        upsertNote(item, updatePersisted: true, syncVisibleList: false);
+      }
+      _listPhase = loadedItems.isEmpty
+          ? NotesListPhase.empty
+          : NotesListPhase.success;
+      _listErrorMessage = null;
+      notifyListeners();
+      return loadedItems;
+    } catch (error) {
+      if (requestId != _listRequestId) {
+        return null;
+      }
+      _listPhase = NotesListPhase.error;
+      _listErrorMessage = 'Notes load failed unexpectedly: $error';
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<rust_api.NoteResponse> loadNoteDetail({required String atomId}) async {
+    return _noteGetInvoker(atomId: atomId);
+  }
+}

--- a/apps/lazynote_flutter/lib/features/notes/notes_controller.dart
+++ b/apps/lazynote_flutter/lib/features/notes/notes_controller.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:lazynote_flutter/core/bindings/api.dart' as rust_api;
 import 'package:lazynote_flutter/core/rust_bridge.dart';
 import 'package:lazynote_flutter/features/notes/managers/note_draft_manager.dart';
+import 'package:lazynote_flutter/features/notes/managers/note_list_manager.dart';
 import 'package:lazynote_flutter/features/notes/managers/note_save_tracker.dart';
 import 'package:lazynote_flutter/features/notes/managers/note_tab_manager.dart';
 import 'package:lazynote_flutter/features/notes/managers/note_tag_manager.dart';
@@ -13,6 +14,7 @@ import 'package:lazynote_flutter/features/workspace/workspace_models.dart';
 import 'package:lazynote_flutter/features/workspace/workspace_provider.dart';
 
 export 'managers/note_draft_manager.dart' show NoteDraftManager;
+export 'managers/note_list_manager.dart' show NoteListManager, NotesListPhase;
 export 'managers/note_save_tracker.dart' show NoteSaveState;
 export 'managers/note_tab_manager.dart' show NoteTabStateManager;
 export 'managers/note_tag_manager.dart' show NoteTagManager;
@@ -56,24 +58,6 @@ typedef DebounceTimerFactory =
 /// Pre-load hook used to ensure bridge/db prerequisites.
 typedef NotesPrepare = Future<void> Function();
 
-/// Stable phase set for C1 list lifecycle.
-enum NotesListPhase {
-  /// No load has started yet.
-  idle,
-
-  /// List request is currently in flight.
-  loading,
-
-  /// List request succeeded with non-empty items.
-  success,
-
-  /// List request succeeded with zero items.
-  empty,
-
-  /// List request failed and carries an error message.
-  error,
-}
-
 /// Stateful controller for Notes page list/detail baseline.
 ///
 /// Contract:
@@ -110,13 +94,14 @@ class NotesController extends ChangeNotifier {
     NotesPrepare? prepare,
     this.listLimit = 50,
     this.autosaveDebounce = const Duration(milliseconds: 1500),
-  }) : _notesListInvoker = notesListInvoker ?? _defaultNotesListInvoker,
-       _noteGetInvoker = noteGetInvoker ?? _defaultNoteGetInvoker,
-       _noteCreateInvoker = noteCreateInvoker ?? _defaultNoteCreateInvoker,
+  }) : _noteCreateInvoker = noteCreateInvoker ?? _defaultNoteCreateInvoker,
        _noteUpdateInvoker = noteUpdateInvoker ?? _defaultNoteUpdateInvoker,
        _noteSetTagsInvoker = noteSetTagsInvoker ?? _defaultNoteSetTagsInvoker,
        _debounceTimerFactory = debounceTimerFactory ?? Timer.new,
        _prepare = prepare ?? _defaultPrepare {
+    final resolvedNotesListInvoker =
+        notesListInvoker ?? _defaultNotesListInvoker;
+    final resolvedNoteGetInvoker = noteGetInvoker ?? _defaultNoteGetInvoker;
     final resolvedTagsListInvoker = tagsListInvoker ?? _defaultTagsListInvoker;
     final resolvedNoteSetTagsInvoker = _noteSetTagsInvoker;
     final resolvedWorkspaceDeleteFolderInvoker =
@@ -141,20 +126,31 @@ class NotesController extends ChangeNotifier {
     _ownsWorkspaceProvider = workspaceProvider == null;
     _noteSaveTracker = NoteSaveTracker(timerFactory: _debounceTimerFactory);
     _noteSaveTracker.addListener(_handleNoteSaveTrackerChanged);
+    _noteListManager = NoteListManager(
+      notesListInvoker: resolvedNotesListInvoker,
+      noteGetInvoker: resolvedNoteGetInvoker,
+      prepare: _prepare,
+      envelopeError: _envelopeError,
+      selectedTag: () => selectedTag,
+      shouldIncludeInVisibleList: _shouldIncludeInVisibleList,
+      isDirty: _isDirty,
+      syncPersistedSnapshot: _syncPersistedSnapshot,
+    );
+    _noteListManager.addListener(_handleNoteListManagerChanged);
     _noteDraftManager = NoteDraftManager(
       noteUpdateInvoker: _noteUpdateInvoker,
       prepare: _prepare,
       activeNoteId: () => _activeNoteId,
-      noteById: (atomId) => _noteCache[atomId],
+      noteById: _noteListManager.cachedNoteById,
       withContent: _withContent,
-      upsertNote: _insertOrReplaceListItem,
+      upsertNote: _noteListManager.upsertNote,
       envelopeError: _envelopeError,
       applySaveState: _setSaveState,
       setSaveError: (message) =>
           _noteSaveTracker.setErrorMessage(message, notify: false),
       syncWorkspaceActiveSnapshot: _syncWorkspaceActiveSnapshot,
       onActiveSaveSuccess: (atomId) {
-        _selectedNote = _noteCache[atomId];
+        _selectedNote = _noteListManager.cachedNoteById(atomId);
         _switchBlockErrorMessage = null;
       },
       timerFactory: _debounceTimerFactory,
@@ -189,11 +185,11 @@ class NotesController extends ChangeNotifier {
               preserveActiveWhenFilteredOut: preserveActiveWhenFilteredOut,
               refreshTags: false,
             );
-            return _listPhase != NotesListPhase.error;
+            return _noteListManager.listPhase != NotesListPhase.error;
           },
       activeNoteId: () => _activeNoteId,
-      noteById: (atomId) => _noteCache[atomId] ?? _selectedNote,
-      upsertNote: _insertOrReplaceListItem,
+      noteById: (atomId) => _noteListManager.noteById(atomId) ?? _selectedNote,
+      upsertNote: _noteListManager.upsertNote,
       isDirty: _isDirty,
       setSaveState: _setSaveState,
       setSaveError: (message) =>
@@ -221,14 +217,12 @@ class NotesController extends ChangeNotifier {
       flushPendingSave: flushPendingSave,
       onDeleteSuccess: _handleWorkspaceDeleteSuccess,
       noteById: noteById,
-      listItems: () => _items,
+      listItems: () => _noteListManager.items,
       titleFromContent: _titleFromContent,
     );
     _workspaceTreeManager.addListener(_handleWorkspaceTreeManagerChanged);
   }
 
-  final NotesListInvoker _notesListInvoker;
-  final NoteGetInvoker _noteGetInvoker;
   final NoteCreateInvoker _noteCreateInvoker;
   final NoteUpdateInvoker _noteUpdateInvoker;
   final NoteSetTagsInvoker _noteSetTagsInvoker;
@@ -237,6 +231,7 @@ class NotesController extends ChangeNotifier {
   late final WorkspaceProvider _workspaceProvider;
   late final bool _ownsWorkspaceProvider;
   late final NoteSaveTracker _noteSaveTracker;
+  late final NoteListManager _noteListManager;
   late final NoteDraftManager _noteDraftManager;
   late final NoteTabStateManager _noteTabManager;
   late final NoteTagManager _noteTagManager;
@@ -248,10 +243,6 @@ class NotesController extends ChangeNotifier {
   /// Debounce window used by autosave pipeline.
   final Duration autosaveDebounce;
 
-  NotesListPhase _listPhase = NotesListPhase.idle;
-  List<rust_api.NoteItem> _items = const [];
-  String? _listErrorMessage;
-
   rust_api.NoteItem? _selectedNote;
   bool _detailLoading = false;
   String? _detailErrorMessage;
@@ -260,24 +251,21 @@ class NotesController extends ChangeNotifier {
   String? _createWarningMessage;
   Future<void>? _createTagApplyFuture;
 
-  final Map<String, rust_api.NoteItem> _noteCache =
-      <String, rust_api.NoteItem>{};
   String? _activeNoteId;
   int _editorFocusRequestId = 0;
   String? _switchBlockErrorMessage;
 
-  int _listRequestId = 0;
   int _detailRequestId = 0;
   bool _disposed = false;
 
   /// Current list phase.
-  NotesListPhase get listPhase => _listPhase;
+  NotesListPhase get listPhase => _noteListManager.listPhase;
 
   /// Current list items from `notes_list`.
-  List<rust_api.NoteItem> get items => List.unmodifiable(_items);
+  List<rust_api.NoteItem> get items => _noteListManager.items;
 
   /// Current list-level error message.
-  String? get listErrorMessage => _listErrorMessage;
+  String? get listErrorMessage => _noteListManager.listErrorMessage;
 
   /// Whether tag catalog request is currently in flight.
   bool get tagsLoading => _noteTagManager.tagsLoading;
@@ -492,7 +480,7 @@ class NotesController extends ChangeNotifier {
 
   /// Returns one cached/list note by id when available.
   rust_api.NoteItem? noteById(String atomId) {
-    return _noteCache[atomId] ?? _findListItem(atomId);
+    return _noteListManager.noteById(atomId);
   }
 
   Map<String, String> get _draftContentByAtomId =>
@@ -523,6 +511,13 @@ class NotesController extends ChangeNotifier {
   Timer? get _autosaveTimer => _noteDraftManager.autosaveTimer;
 
   void _handleNoteSaveTrackerChanged() {
+    if (_disposed) {
+      return;
+    }
+    notifyListeners();
+  }
+
+  void _handleNoteListManagerChanged() {
     if (_disposed) {
       return;
     }
@@ -560,11 +555,13 @@ class NotesController extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
+    _noteListManager.removeListener(_handleNoteListManagerChanged);
     _noteDraftManager.removeListener(_handleNoteDraftManagerChanged);
     _noteTabManager.removeListener(_handleNoteTabManagerChanged);
     _noteTagManager.removeListener(_handleNoteTagManagerChanged);
     _noteSaveTracker.removeListener(_handleNoteSaveTrackerChanged);
     _workspaceTreeManager.removeListener(_handleWorkspaceTreeManagerChanged);
+    _noteListManager.dispose();
     _noteDraftManager.dispose();
     _noteTabManager.dispose();
     _noteTagManager.dispose();
@@ -920,12 +917,12 @@ class NotesController extends ChangeNotifier {
         }
       }
 
-      _listPhase = NotesListPhase.success;
-      _insertOrReplaceListItem(
+      _noteListManager.upsertNote(
         createdNote,
         insertFront: true,
         updatePersisted: true,
       );
+      _noteListManager.markListSuccess();
       _activeNoteId = createdNote.atomId;
       _selectedNote = createdNote;
       _activeDraftAtomId = createdNote.atomId;
@@ -978,7 +975,7 @@ class NotesController extends ChangeNotifier {
     final removedAtomIds = <String>[];
     for (final atomId in openSnapshot) {
       try {
-        final response = await _noteGetInvoker(atomId: atomId);
+        final response = await _noteListManager.loadNoteDetail(atomId: atomId);
         if (!response.ok) {
           if (response.errorCode == 'note_not_found') {
             removedAtomIds.add(atomId);
@@ -986,7 +983,7 @@ class NotesController extends ChangeNotifier {
           continue;
         }
         if (response.note case final note?) {
-          _insertOrReplaceListItem(note, updatePersisted: true);
+          _noteListManager.upsertNote(note, updatePersisted: true);
         }
       } catch (_) {
         // Keep tab state unchanged when detail check fails unexpectedly.
@@ -1048,7 +1045,7 @@ class NotesController extends ChangeNotifier {
 
   void _evictNoteState(String atomId) {
     _noteTabManager.clearPreviewForDeletedAtom(atomId);
-    _noteCache.remove(atomId);
+    _noteListManager.evictNoteState(atomId);
     _draftContentByAtomId.remove(atomId);
     _persistedContentByAtomId.remove(atomId);
     _draftVersionByAtomId.remove(atomId);
@@ -1156,11 +1153,11 @@ class NotesController extends ChangeNotifier {
     _draftContentByAtomId[atomId] = content;
     final version = (_draftVersionByAtomId[atomId] ?? 0) + 1;
     _draftVersionByAtomId[atomId] = version;
-    final current = _noteCache[atomId] ?? _selectedNote;
+    final current = _noteListManager.cachedNoteById(atomId) ?? _selectedNote;
     if (current != null) {
       final updated = _withContent(current, content);
       _selectedNote = updated;
-      _insertOrReplaceListItem(updated);
+      _noteListManager.upsertNote(updated);
     }
     // Why: once user edits preview content, replacing that tab on next open
     // is surprising and risks hidden draft loss. Promote to pinned.
@@ -1182,7 +1179,6 @@ class NotesController extends ChangeNotifier {
     required bool preserveActiveWhenFilteredOut,
     required bool refreshTags,
   }) async {
-    final requestId = ++_listRequestId;
     if (refreshTags) {
       unawaited(_noteTagManager.refreshAvailableTags());
     }
@@ -1191,102 +1187,29 @@ class NotesController extends ChangeNotifier {
       _resetSessionForReload();
     }
 
-    _listPhase = NotesListPhase.loading;
-    _items = const [];
-    _listErrorMessage = null;
     _switchBlockErrorMessage = null;
-    notifyListeners();
+    final loadedItems = await _noteListManager.loadNotes(limit: listLimit);
+    if (loadedItems == null) {
+      return;
+    }
 
-    try {
-      await _prepare();
-      if (requestId != _listRequestId) {
-        return;
-      }
-
-      final response = await _notesListInvoker(
-        tag: selectedTag,
-        limit: listLimit,
-        offset: 0,
-      );
-      if (requestId != _listRequestId) {
-        return;
-      }
-
-      if (!response.ok) {
-        _listPhase = NotesListPhase.error;
-        _listErrorMessage = _envelopeError(
-          errorCode: response.errorCode,
-          message: response.message,
-          fallback: 'Failed to load notes.',
-        );
-        notifyListeners();
-        return;
-      }
-
-      final loadedItems = List<rust_api.NoteItem>.unmodifiable(response.items);
-      _items = loadedItems;
-      for (final item in loadedItems) {
-        // Why: during list fetch, `_items` already equals server-filtered
-        // results. Cache/persisted maps still need refresh, but rewriting
-        // visible list here can re-insert notes that no longer match filter.
-        _insertOrReplaceListItem(
-          item,
-          updatePersisted: true,
-          syncVisibleList: false,
-        );
-      }
-      _listPhase = loadedItems.isEmpty
-          ? NotesListPhase.empty
-          : NotesListPhase.success;
-
-      String? detailTargetId;
-      final activeId = _activeNoteId;
-      final activeInList =
-          activeId != null && _findLoadedItem(loadedItems, activeId) != null;
-      if (activeId == null) {
-        if (loadedItems.isNotEmpty) {
-          final first = loadedItems.first;
-          _activeNoteId = first.atomId;
-          _selectedNote = first;
-          _activeDraftAtomId = first.atomId;
-          _activeDraftContent =
-              _draftContentByAtomId[first.atomId] ?? first.content;
-          _noteTabManager.addOpenNoteIfAbsent(first.atomId);
-          _setSaveState(NoteSaveState.clean);
-          detailTargetId = first.atomId;
-        } else {
-          _selectedNote = null;
-          _detailLoading = false;
-          _detailErrorMessage = null;
-          _activeDraftAtomId = null;
-          _activeDraftContent = '';
-          _setSaveState(NoteSaveState.clean);
-        }
-      } else if (activeInList) {
-        _selectedNote = _findLoadedItem(loadedItems, activeId) ?? _selectedNote;
-        _activeDraftAtomId = activeId;
+    String? detailTargetId;
+    final activeId = _activeNoteId;
+    final activeInList =
+        activeId != null &&
+        _noteListManager.findLoadedItem(loadedItems, activeId) != null;
+    if (activeId == null) {
+      if (loadedItems.isNotEmpty) {
+        final first = loadedItems.first;
+        _activeNoteId = first.atomId;
+        _selectedNote = first;
+        _activeDraftAtomId = first.atomId;
         _activeDraftContent =
-            _draftContentByAtomId[activeId] ?? _selectedNote?.content ?? '';
-        _refreshSaveStateForActive();
-      } else if (preserveActiveWhenFilteredOut) {
-        _selectedNote = _noteCache[activeId] ?? _selectedNote;
-        _activeDraftAtomId = activeId;
-        _activeDraftContent =
-            _draftContentByAtomId[activeId] ?? _selectedNote?.content ?? '';
-        _refreshSaveStateForActive();
-      } else if (loadedItems.isNotEmpty) {
-        final fallback = loadedItems.first;
-        _activeNoteId = fallback.atomId;
-        _selectedNote = fallback;
-        _activeDraftAtomId = fallback.atomId;
-        _activeDraftContent =
-            _draftContentByAtomId[fallback.atomId] ?? fallback.content;
-        _noteTabManager.addOpenNoteIfAbsent(fallback.atomId);
-        _refreshSaveStateForActive();
-        _requestEditorFocus();
-        detailTargetId = fallback.atomId;
+            _draftContentByAtomId[first.atomId] ?? first.content;
+        _noteTabManager.addOpenNoteIfAbsent(first.atomId);
+        _setSaveState(NoteSaveState.clean);
+        detailTargetId = first.atomId;
       } else {
-        _activeNoteId = null;
         _selectedNote = null;
         _detailLoading = false;
         _detailErrorMessage = null;
@@ -1294,20 +1217,47 @@ class NotesController extends ChangeNotifier {
         _activeDraftContent = '';
         _setSaveState(NoteSaveState.clean);
       }
-      _noteTabManager.reconcilePreviewTabState();
-      _syncWorkspaceFromControllerState();
-      notifyListeners();
+    } else if (activeInList) {
+      _selectedNote =
+          _noteListManager.findLoadedItem(loadedItems, activeId) ??
+          _selectedNote;
+      _activeDraftAtomId = activeId;
+      _activeDraftContent =
+          _draftContentByAtomId[activeId] ?? _selectedNote?.content ?? '';
+      _refreshSaveStateForActive();
+    } else if (preserveActiveWhenFilteredOut) {
+      _selectedNote =
+          _noteListManager.cachedNoteById(activeId) ?? _selectedNote;
+      _activeDraftAtomId = activeId;
+      _activeDraftContent =
+          _draftContentByAtomId[activeId] ?? _selectedNote?.content ?? '';
+      _refreshSaveStateForActive();
+    } else if (loadedItems.isNotEmpty) {
+      final fallback = loadedItems.first;
+      _activeNoteId = fallback.atomId;
+      _selectedNote = fallback;
+      _activeDraftAtomId = fallback.atomId;
+      _activeDraftContent =
+          _draftContentByAtomId[fallback.atomId] ?? fallback.content;
+      _noteTabManager.addOpenNoteIfAbsent(fallback.atomId);
+      _refreshSaveStateForActive();
+      _requestEditorFocus();
+      detailTargetId = fallback.atomId;
+    } else {
+      _activeNoteId = null;
+      _selectedNote = null;
+      _detailLoading = false;
+      _detailErrorMessage = null;
+      _activeDraftAtomId = null;
+      _activeDraftContent = '';
+      _setSaveState(NoteSaveState.clean);
+    }
+    _noteTabManager.reconcilePreviewTabState();
+    _syncWorkspaceFromControllerState();
+    notifyListeners();
 
-      if (detailTargetId != null) {
-        await _loadSelectedDetail(atomId: detailTargetId);
-      }
-    } catch (error) {
-      if (requestId != _listRequestId) {
-        return;
-      }
-      _listPhase = NotesListPhase.error;
-      _listErrorMessage = 'Notes load failed unexpectedly: $error';
-      notifyListeners();
+    if (detailTargetId != null) {
+      await _loadSelectedDetail(atomId: detailTargetId);
     }
   }
 
@@ -1317,7 +1267,7 @@ class NotesController extends ChangeNotifier {
     _detailErrorMessage = null;
     _noteTabManager.clearOpenNotes();
     _noteTabManager.reconcilePreviewTabState();
-    _noteCache.clear();
+    _noteListManager.resetSessionState();
     _draftContentByAtomId.clear();
     _persistedContentByAtomId.clear();
     _draftVersionByAtomId.clear();
@@ -1352,7 +1302,7 @@ class NotesController extends ChangeNotifier {
     final requestId = ++_detailRequestId;
     _detailLoading = true;
     _detailErrorMessage = null;
-    _selectedNote = _findListItem(atomId) ?? _selectedNote;
+    _selectedNote = _noteListManager.findListItem(atomId) ?? _selectedNote;
     if (_disposed) {
       return;
     }
@@ -1366,7 +1316,7 @@ class NotesController extends ChangeNotifier {
         return;
       }
 
-      final response = await _noteGetInvoker(atomId: atomId);
+      final response = await _noteListManager.loadNoteDetail(atomId: atomId);
       if (_disposed ||
           requestId != _detailRequestId ||
           atomId != _activeNoteId) {
@@ -1389,7 +1339,7 @@ class NotesController extends ChangeNotifier {
 
       if (response.note case final note?) {
         _selectedNote = note;
-        _insertOrReplaceListItem(note, updatePersisted: true);
+        _noteListManager.upsertNote(note, updatePersisted: true);
         _activeDraftAtomId = note.atomId;
         _activeDraftContent =
             _draftContentByAtomId[note.atomId] ?? note.content;
@@ -1425,63 +1375,16 @@ class NotesController extends ChangeNotifier {
     }
   }
 
-  rust_api.NoteItem? _findLoadedItem(
-    List<rust_api.NoteItem> items,
-    String atomId,
-  ) {
-    for (final item in items) {
-      if (item.atomId == atomId) {
-        return item;
-      }
-    }
-    return null;
-  }
-
-  rust_api.NoteItem? _findListItem(String atomId) {
-    for (final item in _items) {
-      if (item.atomId == atomId) {
-        return item;
-      }
-    }
-    return null;
-  }
-
-  void _insertOrReplaceListItem(
-    rust_api.NoteItem note, {
-    bool insertFront = false,
-    bool updatePersisted = false,
-    bool syncVisibleList = true,
+  void _syncPersistedSnapshot({
+    required String atomId,
+    required String content,
+    required bool wasDirty,
   }) {
-    final wasDirty = _isDirty(note.atomId);
-    _noteCache[note.atomId] = note;
-    if (updatePersisted) {
-      _persistedContentByAtomId[note.atomId] = note.content;
-      _draftVersionByAtomId.putIfAbsent(note.atomId, () => 0);
-      if (!_draftContentByAtomId.containsKey(note.atomId) || !wasDirty) {
-        _draftContentByAtomId[note.atomId] = note.content;
-      }
+    _persistedContentByAtomId[atomId] = content;
+    _draftVersionByAtomId.putIfAbsent(atomId, () => 0);
+    if (!_draftContentByAtomId.containsKey(atomId) || !wasDirty) {
+      _draftContentByAtomId[atomId] = content;
     }
-    if (!syncVisibleList) {
-      return;
-    }
-
-    final includeInVisibleList = _shouldIncludeInVisibleList(note);
-    final mutable = List<rust_api.NoteItem>.from(_items);
-    final existingIndex = mutable.indexWhere(
-      (item) => item.atomId == note.atomId,
-    );
-    if (includeInVisibleList) {
-      if (existingIndex >= 0) {
-        mutable[existingIndex] = note;
-      } else if (insertFront) {
-        mutable.insert(0, note);
-      } else {
-        mutable.add(note);
-      }
-    } else if (existingIndex >= 0) {
-      mutable.removeAt(existingIndex);
-    }
-    _items = List<rust_api.NoteItem>.unmodifiable(mutable);
   }
 
   rust_api.NoteItem _withContent(rust_api.NoteItem current, String content) {
@@ -1571,7 +1474,7 @@ class NotesController extends ChangeNotifier {
     if (persisted != null) {
       return persisted;
     }
-    final cached = _noteCache[atomId];
+    final cached = _noteListManager.cachedNoteById(atomId);
     if (cached != null) {
       return cached.content;
     }
@@ -1603,7 +1506,9 @@ class NotesController extends ChangeNotifier {
         ? _selectedNote
         : null;
     final local =
-        _noteCache[paneActiveId] ?? selected ?? _findListItem(paneActiveId);
+        _noteListManager.cachedNoteById(paneActiveId) ??
+        selected ??
+        _noteListManager.findListItem(paneActiveId);
     _selectedNote = local;
     _activeDraftAtomId = paneActiveId;
     _activeDraftContent = _workspaceDraftContentFor(paneActiveId);

--- a/apps/lazynote_flutter/test/notes_page_c1_test.dart
+++ b/apps/lazynote_flutter/test/notes_page_c1_test.dart
@@ -95,26 +95,42 @@ void main() {
     },
   );
 
-  testWidgets('C1 renders empty state when notes list is empty', (
+  testWidgets('C1 empty state exits after creating first note', (
     WidgetTester tester,
   ) async {
+    final store = <String, rust_api.NoteItem>{};
     final controller = NotesController(
       prepare: () async {},
       notesListInvoker: ({tag, limit, offset}) async {
-        return const rust_api.NotesListResponse(
+        return rust_api.NotesListResponse(
           ok: true,
           errorCode: null,
           message: 'ok',
-          items: [],
+          items: store.values.toList(),
           appliedLimit: 50,
         );
       },
+      noteCreateInvoker: ({required content}) async {
+        final created = note(
+          atomId: 'note-1',
+          content: content,
+          previewText: '',
+          updatedAt: 1,
+        );
+        store[created.atomId] = created;
+        return rust_api.NoteResponse(
+          ok: true,
+          errorCode: null,
+          message: 'ok',
+          note: created,
+        );
+      },
       noteGetInvoker: ({required atomId}) async {
-        return const rust_api.NoteResponse(
-          ok: false,
-          errorCode: 'not_found',
-          message: 'not found',
-          note: null,
+        return rust_api.NoteResponse(
+          ok: true,
+          errorCode: null,
+          message: 'ok',
+          note: store[atomId],
         );
       },
     );
@@ -127,6 +143,13 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const Key('notes_list_empty')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('notes_create_button')));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const Key('notes_list_empty')), findsNothing);
+    expect(find.byKey(const Key('notes_list_item_note-1')), findsOneWidget);
   });
 
   testWidgets('C1 renders error and retry path can recover', (

--- a/docs/releases/v0.2.5/prs/PR-0252/P2-2-note-list-manager.md
+++ b/docs/releases/v0.2.5/prs/PR-0252/P2-2-note-list-manager.md
@@ -9,7 +9,7 @@
 | Branch | `feat/pr-0252-p2-2-note-list-manager` |
 | PR Title | `refactor(frontend): PR-0252 P2-2 extract note list manager` |
 | Estimated Effort | 1.5 person-day |
-| Status | Planned |
+| Status | Ready for Review |
 
 ## References
 
@@ -51,10 +51,10 @@ Out of scope:
 
 ## Acceptance Criteria
 
-- [ ] 独立 ChangeNotifier，持有 notesList + noteGet invoker
-- [ ] <400 行
-- [ ] CI 全绿
-- [ ] 测试基线不变（313 pass / 0 known-fail）
+- [x] 独立 ChangeNotifier，持有 notesList + noteGet invoker
+- [x] <400 行（`managers/note_list_manager.dart` 228 行）
+- [x] CI 全绿
+- [x] 测试基线不变（333 pass / 0 known-fail）
 
 ## CI Gates
 
@@ -85,3 +85,9 @@ flutter build windows --debug
 
 独立 revert 即可。删除 `note_list_manager.dart`，回退 `notes_controller.dart` facade 改动。
 
+## Verification Snapshot (2026-02-26)
+
+- `dart format lib/features/notes/managers/note_list_manager.dart lib/features/notes/notes_controller.dart`：通过
+- `flutter analyze`：通过（No issues found）
+- `flutter test`：通过（333 pass）
+- `flutter build windows --debug`：通过

--- a/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
+++ b/docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md
@@ -333,7 +333,7 @@
 | 任务 ID | 任务名称 | 模块 | 类型 | 前置依赖 | 负责人 | 预计人日 | 输出物 | 验收标准 | 状态 |
 |---------|---------|------|------|---------|--------|---------|--------|---------|------|
 | P2-1 | 提取 NoteTabManager | notes/managers | 结构拆分 | P0-4 + P1-2 | Agent | 1.5 | PR | 独立 ChangeNotifier，整合现有 `note_tab_manager.dart` (431行 UI) + controller Tab 逻辑，<400 行状态层；CI 全绿 | 已完成（2026-02-26） |
-| P2-2 | 提取 NoteListManager | notes/managers | 结构拆分 | P1-3 + P2-1 | Agent | 1.5 | PR | 独立 ChangeNotifier，持有 notesList + noteGet invoker，<400 行；CI 全绿 | 未开始 |
+| P2-2 | 提取 NoteListManager | notes/managers | 结构拆分 | P1-3 + P2-1 | Agent | 1.5 | PR | 独立 ChangeNotifier，持有 notesList + noteGet invoker，<400 行；CI 全绿 | 评审中（2026-02-26） |
 | P2-3 | 创建 NotesCoordinator + 消费者迁移 | notes | 结构拆分 | P2-1 + P2-2 | Agent | 1.5 | PR | Coordinator <300 行；6 个消费者文件（NotesPage, NoteContentArea, NoteExplorer, NoteTabManager, first_party_ui_slots, entry_shell_page）全部从 `_controller` 迁移到 `_coordinator`；原 `notes_controller.dart` 删除；CI 全绿 | 未开始 |
 | P2-4 | 测试批量迁移 | notes | 测试 | P2-3 | Agent | 0.5 | PR | 16 个测试文件中的 `NotesController` 引用全部适配为 `NotesCoordinator`；333 pass / 0 known-fail 基线不变 | 未开始 |
 | P2-5 | ExplorerTreeBuilder 参数收敛（可选） | notes | 结构优化 | P2-3 | Agent | 0.5 | PR | `ExplorerTreeBuilder` 构造参数从 28 收敛为配置对象（如 `ExplorerTreeBuilderConfig`），行为不变；CI 全绿 | 未开始（可选，非阻塞） |


### PR DESCRIPTION
## Summary
- Extracted `NoteListManager` as an independent `ChangeNotifier` for list state, cache, and list/detail loading.
- Kept `NotesController` as a facade layer with stable external API.
- Moved list-domain logic from controller into manager and wired persisted-snapshot sync via callback.
- Fixed a regression in create flow for empty list:
  - create now does `upsertNote()` before `markListSuccess()` so phase is not stuck in `empty`.
- Restored `_adoptWorkspaceActivePaneState` lookup order to preserve prior behavior:
  - cache -> selectedNote -> list.
- Added regression coverage for empty-list create-first-note path.
- Updated tracking docs for P2-2 status and verification snapshot.

## Scope
- `apps/lazynote_flutter/lib/features/notes/managers/note_list_manager.dart` (new)
- `apps/lazynote_flutter/lib/features/notes/notes_controller.dart` (refactor + regression fix)
- `apps/lazynote_flutter/test/notes_page_c1_test.dart` (regression test update)
- `docs/releases/v0.2.5/prs/PR-0252/P2-2-note-list-manager.md` (status/AC/snapshot)
- `docs/reports/v0.2.5/frontend-review/03-phased-refactor-plan.md` (P2-2 status)

## Validation
- `dart format --set-exit-if-changed` passed
- `flutter analyze` passed
- `flutter test` passed (`333 passed`)
- `flutter build windows --debug` passed

## Compatibility
- No public API signature changes.
- No breaking changes introduced.
