### PR TITLE
refactor(frontend): PR-0252 P3-1 create section registry and decouple entry shell

### DIFF
--- a/apps/lazynote_flutter/lib/app/app.dart
+++ b/apps/lazynote_flutter/lib/app/app.dart
@@ -2,8 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:lazynote_flutter/app/app_locale_controller.dart';
 import 'package:lazynote_flutter/app/routes.dart';
+import 'package:lazynote_flutter/app/section_registry.dart';
+import 'package:lazynote_flutter/app/ui_slots/first_party_ui_slots.dart';
+import 'package:lazynote_flutter/app/ui_slots/ui_slot_registry.dart';
 import 'package:lazynote_flutter/core/settings/local_settings_store.dart';
+import 'package:lazynote_flutter/features/calendar/calendar_page.dart';
+import 'package:lazynote_flutter/features/diagnostics/rust_diagnostics_page.dart';
 import 'package:lazynote_flutter/features/entry/entry_shell_page.dart';
+import 'package:lazynote_flutter/features/notes/notes_coordinator.dart';
+import 'package:lazynote_flutter/features/notes/notes_page.dart';
+import 'package:lazynote_flutter/features/settings/settings_capability_page.dart';
+import 'package:lazynote_flutter/features/tasks/tasks_page.dart';
 import 'package:lazynote_flutter/l10n/app_localizations.dart';
 
 /// Root app shell for the Windows-first UI stage.
@@ -19,6 +28,9 @@ class LazyNoteApp extends StatefulWidget {
 class _LazyNoteAppState extends State<LazyNoteApp> {
   late final AppLocaleController _localeController;
   late final bool _ownsLocaleController;
+  late final NotesCoordinator _notesCoordinator;
+  late final UiSlotRegistry _uiSlotRegistry;
+  late final SectionRegistry _sectionRegistry;
 
   @override
   void initState() {
@@ -27,14 +39,104 @@ class _LazyNoteAppState extends State<LazyNoteApp> {
     _localeController =
         widget.localeController ??
         AppLocaleController(initialLanguage: LocalSettingsStore.uiLanguage);
+    _notesCoordinator = NotesCoordinator();
+    _uiSlotRegistry = createFirstPartyUiSlotRegistry();
+    _sectionRegistry = _buildSectionRegistry();
   }
 
   @override
   void dispose() {
+    _notesCoordinator.dispose();
     if (_ownsLocaleController) {
       _localeController.dispose();
     }
     super.dispose();
+  }
+
+  SectionRegistry _buildSectionRegistry() {
+    final registry = SectionRegistry(
+      listenable: _notesCoordinator.workspaceProvider,
+    );
+
+    registry.register(
+      SectionRegistration(
+        id: WorkbenchSectionIds.notes,
+        builder: (context, onBack) => NotesPage(
+          controller: _notesCoordinator,
+          onBackToWorkbench: onBack,
+          uiSlotRegistry: _uiSlotRegistry,
+        ),
+        titleBuilder: (context) {
+          final l10n = AppLocalizations.of(context)!;
+          final workspace = _notesCoordinator.workspaceProvider;
+          final openTabs =
+              workspace.openTabsByPane[workspace.activePaneId] ??
+              const <String>[];
+          return openTabs.isEmpty
+              ? l10n.workbenchSectionNotes
+              : l10n.workbenchSectionNotesWithCount(openTabs.length);
+        },
+      ),
+    );
+
+    registry.register(
+      SectionRegistration(
+        id: WorkbenchSectionIds.tasks,
+        builder: (context, onBack) => TasksPage(onBackToWorkbench: onBack),
+        titleBuilder: (context) =>
+            AppLocalizations.of(context)!.workbenchSectionTasks,
+      ),
+    );
+
+    registry.register(
+      SectionRegistration(
+        id: WorkbenchSectionIds.calendar,
+        builder: (context, onBack) => CalendarPage(onBackToWorkbench: onBack),
+        titleBuilder: (context) =>
+            AppLocalizations.of(context)!.workbenchSectionCalendar,
+      ),
+    );
+
+    registry.register(
+      SectionRegistration(
+        id: WorkbenchSectionIds.settings,
+        builder: (context, onBack) => SettingsCapabilityPage(
+          onBackToWorkbench: onBack,
+          localeController: _localeController,
+        ),
+        titleBuilder: (context) =>
+            AppLocalizations.of(context)!.workbenchSectionSettings,
+      ),
+    );
+
+    registry.register(
+      SectionRegistration(
+        id: WorkbenchSectionIds.rustDiagnostics,
+        builder: (context, onBack) {
+          final l10n = AppLocalizations.of(context)!;
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.workbenchSectionRustDiagnostics,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 12),
+              const RustDiagnosticsContent(),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: onBack,
+                child: Text(l10n.backToWorkbenchButton),
+              ),
+            ],
+          );
+        },
+        titleBuilder: (context) =>
+            AppLocalizations.of(context)!.workbenchSectionRustDiagnostics,
+      ),
+    );
+
+    return registry;
   }
 
   @override
@@ -57,25 +159,39 @@ class _LazyNoteAppState extends State<LazyNoteApp> {
           locale: _localeController.localeOverride,
           initialRoute: AppRoutes.workbench,
           routes: {
-            AppRoutes.workbench: (_) =>
-                EntryShellPage(localeController: _localeController),
-            AppRoutes.entry: (_) =>
-                EntryShellPage(localeController: _localeController),
-            AppRoutes.notes: (_) => EntryShellPage(
-              initialSection: WorkbenchSection.notes,
+            AppRoutes.workbench: (_) => EntryShellPage(
               localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
+            ),
+            AppRoutes.entry: (_) => EntryShellPage(
+              localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
+            ),
+            AppRoutes.notes: (_) => EntryShellPage(
+              initialSection: WorkbenchSectionIds.notes,
+              localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
             ),
             AppRoutes.tasks: (_) => EntryShellPage(
-              initialSection: WorkbenchSection.tasks,
+              initialSection: WorkbenchSectionIds.tasks,
               localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
             ),
             AppRoutes.settings: (_) => EntryShellPage(
-              initialSection: WorkbenchSection.settings,
+              initialSection: WorkbenchSectionIds.settings,
               localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
             ),
             AppRoutes.rustDiagnostics: (_) => EntryShellPage(
-              initialSection: WorkbenchSection.rustDiagnostics,
+              initialSection: WorkbenchSectionIds.rustDiagnostics,
               localeController: _localeController,
+              sectionRegistry: _sectionRegistry,
+              uiSlotRegistry: _uiSlotRegistry,
             ),
           },
         );

--- a/apps/lazynote_flutter/lib/app/section_registry.dart
+++ b/apps/lazynote_flutter/lib/app/section_registry.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/widgets.dart';
+
+/// Builder for a section's content widget.
+///
+/// Receives the current [BuildContext] and an [onBackToWorkbench] callback
+/// that sections should invoke to navigate back to the home section.
+typedef SectionWidgetBuilder =
+    Widget Function(BuildContext context, VoidCallback onBackToWorkbench);
+
+/// Builder for a section's dynamic title string.
+typedef SectionTitleBuilder = String Function(BuildContext context);
+
+/// A single registered workbench section.
+class SectionRegistration {
+  const SectionRegistration({
+    required this.id,
+    required this.builder,
+    required this.titleBuilder,
+  });
+
+  /// Section identifier (use [WorkbenchSectionIds] constants).
+  final String id;
+
+  /// Builds the section content widget.
+  final SectionWidgetBuilder builder;
+
+  /// Builds the section title for the shell layout title bar.
+  final SectionTitleBuilder titleBuilder;
+}
+
+/// Registry of workbench sections.
+///
+/// Sections are registered in the app layer (composition root) and consumed
+/// by [EntryShellPage] without cross-feature imports.
+class SectionRegistry {
+  SectionRegistry({this.listenable});
+
+  /// Optional listenable for triggering shell rebuilds
+  /// (e.g., workspace tab count changes affecting the title bar).
+  final Listenable? listenable;
+
+  final Map<String, SectionRegistration> _sections = {};
+
+  /// Registers a section. Replaces any existing section with the same id.
+  void register(SectionRegistration section) {
+    _sections[section.id] = section;
+  }
+
+  /// Returns the registration for [id], or `null` if not registered.
+  SectionRegistration? operator [](String id) => _sections[id];
+}

--- a/apps/lazynote_flutter/lib/features/entry/entry_shell_page.dart
+++ b/apps/lazynote_flutter/lib/features/entry/entry_shell_page.dart
@@ -1,29 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:lazynote_flutter/app/app_locale_controller.dart';
+import 'package:lazynote_flutter/app/section_registry.dart';
 import 'package:lazynote_flutter/app/ui_slots/first_party_ui_slots.dart';
 import 'package:lazynote_flutter/app/ui_slots/ui_slot_host.dart';
 import 'package:lazynote_flutter/app/ui_slots/ui_slot_models.dart';
 import 'package:lazynote_flutter/app/ui_slots/ui_slot_registry.dart';
-import 'package:lazynote_flutter/features/calendar/calendar_page.dart';
-import 'package:lazynote_flutter/features/diagnostics/rust_diagnostics_page.dart';
 import 'package:lazynote_flutter/features/entry/single_entry_controller.dart';
 import 'package:lazynote_flutter/features/entry/single_entry_panel.dart';
 import 'package:lazynote_flutter/features/entry/workbench_shell_layout.dart';
-import 'package:lazynote_flutter/features/notes/notes_coordinator.dart';
-import 'package:lazynote_flutter/features/notes/notes_page.dart';
-import 'package:lazynote_flutter/features/settings/settings_capability_page.dart';
-import 'package:lazynote_flutter/features/tasks/tasks_page.dart';
 import 'package:lazynote_flutter/l10n/app_localizations.dart';
-
-/// Left-pane sections inside Workbench shell.
-enum WorkbenchSection {
-  home,
-  notes,
-  tasks,
-  calendar,
-  settings,
-  rustDiagnostics,
-}
 
 /// Default shell page used to validate new features before wiring final UIs.
 ///
@@ -32,13 +17,15 @@ enum WorkbenchSection {
 class EntryShellPage extends StatefulWidget {
   const EntryShellPage({
     super.key,
-    this.initialSection = WorkbenchSection.home,
+    this.initialSection = WorkbenchSectionIds.home,
+    this.sectionRegistry,
     this.uiSlotRegistry,
     this.localeController,
   });
 
   /// Initial left-pane section to render inside Workbench shell.
-  final WorkbenchSection initialSection;
+  final String initialSection;
+  final SectionRegistry? sectionRegistry;
   final UiSlotRegistry? uiSlotRegistry;
   final AppLocaleController? localeController;
 
@@ -49,53 +36,37 @@ class EntryShellPage extends StatefulWidget {
 class _EntryShellPageState extends State<EntryShellPage> {
   // Single Entry is the primary interactive path in Workbench after PR-0009C.
   final SingleEntryController _singleEntryController = SingleEntryController();
-  final NotesCoordinator _notesCoordinator = NotesCoordinator();
   late final UiSlotRegistry _uiSlotRegistry;
-  late WorkbenchSection _activeSection;
+  late String _activeSection;
   bool _showSingleEntryPanel = false;
 
   @override
   void initState() {
     super.initState();
     _uiSlotRegistry = widget.uiSlotRegistry ?? createFirstPartyUiSlotRegistry();
-    _activeSection = widget.initialSection;
+    final initial = widget.initialSection;
+    _activeSection =
+        initial == WorkbenchSectionIds.home ||
+            widget.sectionRegistry?[initial] != null
+        ? initial
+        : WorkbenchSectionIds.home;
   }
 
   @override
   void dispose() {
     _singleEntryController.dispose();
-    _notesCoordinator.dispose();
     super.dispose();
   }
 
-  void _openSection(WorkbenchSection section) {
+  void _openSection(String sectionId) {
+    final resolved =
+        sectionId == WorkbenchSectionIds.home ||
+            widget.sectionRegistry?[sectionId] != null
+        ? sectionId
+        : WorkbenchSectionIds.home;
     setState(() {
-      _activeSection = section;
+      _activeSection = resolved;
     });
-  }
-
-  void _openSectionById(String sectionId) {
-    final section = switch (sectionId) {
-      WorkbenchSectionIds.home => WorkbenchSection.home,
-      WorkbenchSectionIds.notes => WorkbenchSection.notes,
-      WorkbenchSectionIds.tasks => WorkbenchSection.tasks,
-      WorkbenchSectionIds.calendar => WorkbenchSection.calendar,
-      WorkbenchSectionIds.settings => WorkbenchSection.settings,
-      WorkbenchSectionIds.rustDiagnostics => WorkbenchSection.rustDiagnostics,
-      _ => WorkbenchSection.home,
-    };
-    _openSection(section);
-  }
-
-  String _sectionId(WorkbenchSection section) {
-    return switch (section) {
-      WorkbenchSection.home => WorkbenchSectionIds.home,
-      WorkbenchSection.notes => WorkbenchSectionIds.notes,
-      WorkbenchSection.tasks => WorkbenchSectionIds.tasks,
-      WorkbenchSection.calendar => WorkbenchSectionIds.calendar,
-      WorkbenchSection.settings => WorkbenchSectionIds.settings,
-      WorkbenchSection.rustDiagnostics => WorkbenchSectionIds.rustDiagnostics,
-    };
   }
 
   void _openOrFocusSingleEntryPanel() {
@@ -114,22 +85,15 @@ class _EntryShellPageState extends State<EntryShellPage> {
     });
   }
 
-  String _titleForSection(BuildContext context, WorkbenchSection section) {
-    final l10n = AppLocalizations.of(context)!;
-    final workspace = _notesCoordinator.workspaceProvider;
-    final openTabs =
-        workspace.openTabsByPane[workspace.activePaneId] ?? const <String>[];
-    return switch (section) {
-      WorkbenchSection.home => l10n.lazyNoteWorkbenchTitle,
-      WorkbenchSection.notes =>
-        openTabs.isEmpty
-            ? l10n.workbenchSectionNotes
-            : l10n.workbenchSectionNotesWithCount(openTabs.length),
-      WorkbenchSection.tasks => l10n.workbenchSectionTasks,
-      WorkbenchSection.calendar => l10n.workbenchSectionCalendar,
-      WorkbenchSection.settings => l10n.workbenchSectionSettings,
-      WorkbenchSection.rustDiagnostics => l10n.workbenchSectionRustDiagnostics,
-    };
+  String _titleForSection(BuildContext context) {
+    if (_activeSection == WorkbenchSectionIds.home) {
+      return AppLocalizations.of(context)!.lazyNoteWorkbenchTitle;
+    }
+    final registration = widget.sectionRegistry?[_activeSection];
+    if (registration != null) {
+      return registration.titleBuilder(context);
+    }
+    return '';
   }
 
   Widget _buildWorkbenchHome() {
@@ -189,7 +153,7 @@ class _EntryShellPageState extends State<EntryShellPage> {
           layer: UiSlotLayer.contentBlock,
           slotContext: UiSlotContext({
             UiSlotContextKeys.onOpenDiagnostics: () {
-              _openSection(WorkbenchSection.rustDiagnostics);
+              _openSection(WorkbenchSectionIds.rustDiagnostics);
             },
           }),
           listBuilder: (context, children) {
@@ -214,7 +178,7 @@ class _EntryShellPageState extends State<EntryShellPage> {
                 const SizedBox(height: 8),
                 OutlinedButton(
                   onPressed: () =>
-                      _openSection(WorkbenchSection.rustDiagnostics),
+                      _openSection(WorkbenchSectionIds.rustDiagnostics),
                   child: Text(l10n.workbenchSectionRustDiagnostics),
                 ),
               ],
@@ -232,7 +196,7 @@ class _EntryShellPageState extends State<EntryShellPage> {
           slotId: UiSlotIds.workbenchHomeWidgets,
           layer: UiSlotLayer.homeWidget,
           slotContext: UiSlotContext({
-            UiSlotContextKeys.onOpenSection: _openSectionById,
+            UiSlotContextKeys.onOpenSection: _openSection,
           }),
           listBuilder: (context, children) {
             return Wrap(spacing: 12, runSpacing: 12, children: children);
@@ -243,19 +207,19 @@ class _EntryShellPageState extends State<EntryShellPage> {
               runSpacing: 12,
               children: [
                 OutlinedButton(
-                  onPressed: () => _openSection(WorkbenchSection.notes),
+                  onPressed: () => _openSection(WorkbenchSectionIds.notes),
                   child: Text(l10n.workbenchSectionNotes),
                 ),
                 OutlinedButton(
-                  onPressed: () => _openSection(WorkbenchSection.tasks),
+                  onPressed: () => _openSection(WorkbenchSectionIds.tasks),
                   child: Text(l10n.workbenchSectionTasks),
                 ),
                 OutlinedButton(
-                  onPressed: () => _openSection(WorkbenchSection.calendar),
+                  onPressed: () => _openSection(WorkbenchSectionIds.calendar),
                   child: Text(l10n.workbenchSectionCalendar),
                 ),
                 OutlinedButton(
-                  onPressed: () => _openSection(WorkbenchSection.settings),
+                  onPressed: () => _openSection(WorkbenchSectionIds.settings),
                   child: Text(l10n.workbenchSectionSettings),
                 ),
               ],
@@ -266,97 +230,49 @@ class _EntryShellPageState extends State<EntryShellPage> {
     );
   }
 
-  Widget _buildRustDiagnosticsSection() {
-    final l10n = AppLocalizations.of(context)!;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          l10n.workbenchSectionRustDiagnostics,
-          style: Theme.of(context).textTheme.headlineSmall,
-        ),
-        const SizedBox(height: 12),
-        const RustDiagnosticsContent(),
-        const SizedBox(height: 16),
-        FilledButton(
-          onPressed: () => _openSection(WorkbenchSection.home),
-          child: Text(l10n.backToWorkbenchButton),
-        ),
-      ],
-    );
-  }
-
   Widget _buildActiveLeftContent() {
     return UiSlotViewHost(
       registry: _uiSlotRegistry,
       slotId: UiSlotIds.workbenchSectionView,
       slotContext: UiSlotContext({
-        UiSlotContextKeys.activeSection: _sectionId(_activeSection),
+        UiSlotContextKeys.activeSection: _activeSection,
         UiSlotContextKeys.onBackToWorkbench: () {
-          _openSection(WorkbenchSection.home);
+          _openSection(WorkbenchSectionIds.home);
         },
       }),
       fallbackBuilder: (context) {
-        return switch (_activeSection) {
-          WorkbenchSection.home => _buildWorkbenchHome(),
-          WorkbenchSection.notes => NotesPage(
-            controller: _notesCoordinator,
-            onBackToWorkbench: () => _openSection(WorkbenchSection.home),
-            uiSlotRegistry: _uiSlotRegistry,
-          ),
-          WorkbenchSection.tasks => TasksPage(
-            onBackToWorkbench: () => _openSection(WorkbenchSection.home),
-          ),
-          WorkbenchSection.calendar => CalendarPage(
-            onBackToWorkbench: () => _openSection(WorkbenchSection.home),
-          ),
-          WorkbenchSection.settings => SettingsCapabilityPage(
-            onBackToWorkbench: () => _openSection(WorkbenchSection.home),
-            localeController: widget.localeController,
-          ),
-          WorkbenchSection.rustDiagnostics => _buildRustDiagnosticsSection(),
-        };
+        if (_activeSection == WorkbenchSectionIds.home) {
+          return _buildWorkbenchHome();
+        }
+        final registration = widget.sectionRegistry?[_activeSection];
+        if (registration != null) {
+          return registration.builder(
+            context,
+            () => _openSection(WorkbenchSectionIds.home),
+          );
+        }
+        return _buildWorkbenchHome();
       },
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final listenable = widget.sectionRegistry?.listenable;
+    if (listenable == null) {
+      return WorkbenchShellLayout(
+        title: _titleForSection(context),
+        content: _buildActiveLeftContent(),
+      );
+    }
     return AnimatedBuilder(
-      animation: _notesCoordinator.workspaceProvider,
+      animation: listenable,
       builder: (context, _) {
         return WorkbenchShellLayout(
-          title: _titleForSection(context, _activeSection),
+          title: _titleForSection(context),
           content: _buildActiveLeftContent(),
         );
       },
     );
-  }
-}
-
-/// Compatibility wrapper for legacy direct route entries.
-class FeaturePlaceholderPage extends StatelessWidget {
-  const FeaturePlaceholderPage({
-    super.key,
-    required this.title,
-    required this.description,
-  });
-
-  /// Placeholder title used to map route into a Workbench section.
-  final String title;
-
-  /// Placeholder text shown by the mapped section.
-  final String description;
-
-  @override
-  Widget build(BuildContext context) {
-    final section = switch (title.toLowerCase()) {
-      'notes' => WorkbenchSection.notes,
-      'tasks' => WorkbenchSection.tasks,
-      'calendar' => WorkbenchSection.calendar,
-      'settings' => WorkbenchSection.settings,
-      _ => WorkbenchSection.home,
-    };
-    return EntryShellPage(initialSection: section);
   }
 }


### PR DESCRIPTION
## What / Why
实现 PR-0252 的 P3-1：引入 SectionRegistry，将 EntryShellPage 从跨 feature 直接依赖改为通过 app 层注册 section builder，实现解耦并保持行为不变。

## Scope
- 新增 `apps/lazynote_flutter/lib/app/section_registry.dart`
  - 定义 `SectionRegistration` 与 `SectionRegistry`
- 修改 `apps/lazynote_flutter/lib/app/app.dart`
  - 在 app composition root 注册 notes/tasks/calendar/settings/rustDiagnostics section
  - 将 `sectionRegistry` 与 `uiSlotRegistry` 注入 `EntryShellPage`
- 修改 `apps/lazynote_flutter/lib/features/entry/entry_shell_page.dart`
  - 移除跨 feature import
  - 使用 `String sectionId` + registry 查询渲染与标题
  - 增加 sectionId 归一化（initState 与 _openSection：未知 id 回退到 home）
  - 删除无调用方死代码 `FeaturePlaceholderPage`

## Validation
- `flutter analyze`：通过（0 issue）
- `flutter test`：通过（333 pass / 0 fail）
- `flutter build windows --debug`：通过
- Rule E 检查：`entry_shell_page.dart` 仅保留 `features/entry/*` import

## Risk / Rollback
- 风险低：注册方式变化，section 渲染逻辑不变
- 可独立回滚：删除 `section_registry.dart` 并回退 `app.dart` / `entry_shell_page.dart`
